### PR TITLE
Cleanup helm chart env vars

### DIFF
--- a/chart/ipam-api/templates/deployment.yaml
+++ b/chart/ipam-api/templates/deployment.yaml
@@ -59,45 +59,18 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+        {{- if .Values.api.extraEnvVars }}
           env:
-            - name: IPAMAPI_SERVER_LISTEN
-              value: ":{{ .Values.api.listenPort }}"
-            - name: IPAMAPI_SERVER_SHUTDOWN_GRACE_PERIOD
-              value: "{{ .Values.api.shutdownGracePeriod }}"
-          {{- with .Values.api.trustedProxies }}
-            - name: IPAMAPI_SERVER_TRUSTED_PROXIES
-              value: "{{ join " " . }}"
+          {{- range .Values.api.extraEnvVars }}
+            - name: {{ .name }}
+              value: {{ .value }}
           {{- end }}
-            - name: IPAMAPI_NATS_URL
-              value: "{{ .Values.api.events.connectionURL }}"
-            - name: IPAMAPI_NATS_STREAM_NAME
-              value: "{{ .Values.api.events.queue | default "ipamapi" }}"
-            - name: IPAMAPI_NATS_SUBJECT_PREFIX
-              value: "{{ .Values.api.events.subjects }}"
-          {{- if .Values.api.events.auth.secretName }}
-            - name: IPAMAPI_NATS_CREDS_FILE
-              value: "{{ .Values.api.events.credsPath }}"
-          {{- end }}
-          {{- if .Values.api.oidc.enabled }}
-          {{- with .Values.api.oidc.audience }}
-            - name: IPAMAPI_OIDC_AUDIENCE
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.api.oidc.issuer }}
-            - name: IPAMAPI_OIDC_ISSUER
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.api.oidc.jwks.remoteTimeout }}
-            - name: IPAMAPI_OIDC_JWKS_REMOTE_TIMEOUT
-              value: "{{ . }}"
-          {{- end }}
-          {{- else }}
-            - name: IPAMAPI_OIDC_ENABLED
-              value: "false"
           {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.api.db.uriSecret }}
+            - configMapRef:
+                name: {{ include "common.names.fullname" . }}-config
           {{- with .Values.api.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/chart/ipam-api/values.yaml
+++ b/chart/ipam-api/values.yaml
@@ -43,8 +43,7 @@ api:
     auth:
       secretName: "events-creds"
       credsPath: "/nats/creds"
-    subjects: "events"
-    queue: "ipan"
+    topicPrefix: "com.infratographer"
   db:
     uriSecret: ipam-api-db-uri
     certSecret: ipam-api-db-ca

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,18 +48,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/."+appName+".yaml)")
 	viperx.MustBindFlag(viper.GetViper(), "config", rootCmd.PersistentFlags().Lookup("config"))
 
-	rootCmd.PersistentFlags().String("nats-url", "nats://nats:4222", "NATS server connection url")
-	viperx.MustBindFlag(viper.GetViper(), "nats.url", rootCmd.PersistentFlags().Lookup("nats-url"))
-
-	rootCmd.PersistentFlags().String("nats-creds-file", "", "Path to the file containing the NATS nkey keypair")
-	viperx.MustBindFlag(viper.GetViper(), "nats.creds-file", rootCmd.PersistentFlags().Lookup("nats-creds-file"))
-
-	rootCmd.PersistentFlags().String("nats-subject-prefix", "com.infratographer.events", "prefix for NATS subjects")
-	viperx.MustBindFlag(viper.GetViper(), "nats.subject-prefix", rootCmd.PersistentFlags().Lookup("nats-subject-prefix"))
-
-	rootCmd.PersistentFlags().String("nats-stream-name", "load-balancer-api", "nats stream name")
-	viperx.MustBindFlag(viper.GetViper(), "nats.stream-name", rootCmd.PersistentFlags().Lookup("nats-stream-name"))
-
 	// Logging flags
 	loggingx.MustViperFlags(viper.GetViper(), rootCmd.PersistentFlags())
 


### PR DESCRIPTION
Cleans up helm chart to set environment variables via configmap instead of individually. Also cleans up previous usage of NATS specific flags.