### PR TITLE
Add get ip addresses by nodeID to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # Go workspace file
 go.work

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,12 @@ generate: background-run .generate kill-running ## Generates code
 go-run: ## Runs the app
 	@echo --- Running binary...
 	@date --rfc-3339=seconds
-	@go run main.go serve --playground --dev
+	@go run main.go serve --playground --dev --oidc=false
 
 background-run:  ## Runs in the app in the background
 	@echo --- Running binary in the background...
 	@date --rfc-3339=seconds
-	@go run main.go serve --pid-file=${PID_FILE} &
+	@go run main.go serve --dev --oidc=false --pid-file=${PID_FILE} &
 
 kill-running: ## Kills the running binary from pid file
 	@echo --- Killing background binary...

--- a/pkg/ipamclient/client.go
+++ b/pkg/ipamclient/client.go
@@ -2,6 +2,7 @@ package ipamclient
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/3th1nk/cidr"
@@ -184,4 +185,23 @@ func (c *Client) DeleteIPAddress(ctx context.Context, id string) (*DeleteIPAddre
 	}
 
 	return &ipd, nil
+}
+
+// GetIPAddresses returns a list of IP Addresses by node id
+func (c *Client) GetIPAddresses(ctx context.Context, nodeID string) (*GetIPAddressesByNode, error) {
+	_, err := gidx.Parse(nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	vars := map[string]interface{}{
+		"representations": fmt.Sprintf(`{"__typename": "IPAddressable", "id": "%s"}`, nodeID),
+	}
+
+	var ipas GetIPAddressesByNode
+	if err := c.gqlCli.Query(ctx, &ipas, vars); err != nil {
+		return nil, err
+	}
+
+	return &ipas, nil
 }

--- a/pkg/ipamclient/client_test.go
+++ b/pkg/ipamclient/client_test.go
@@ -2,8 +2,12 @@ package ipamclient
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/shurcooL/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -151,4 +155,77 @@ func TestCreateIPAddressFromBlock(t *testing.T) {
 	ip, err = cli.CreateIPAddressFromBlock(context.Background(), "badprefix-test", "loadbal-12345", "testtnt-123456", true)
 	require.Error(t, err)
 	require.Nil(t, ip)
+}
+
+func TestGetIPAddressesByNodeID(t *testing.T) {
+	cli := Client{
+		gqlCli: mustNewGQLTestClient(`{
+  "data": {
+    "_entities": [
+      {
+        "id": "loadbal-randovalue",
+        "IPAddresses": [
+          {
+            "id": "ipamipa-8IPzP37YJ1iTxJdMrCods",
+            "ip": "192.168.1.142",
+            "reserved": false
+          },
+          {
+            "id": "ipamipa-rPBY83fPw6Ll5sueCMpDr",
+            "ip": "192.168.1.1",
+            "reserved": true
+          }
+        ]
+      }
+    ]
+  }
+}`),
+	}
+
+	t.Run("invalid prefix", func(t *testing.T) {
+		ips, err := cli.GetIPAddresses(context.Background(), "badprefix-test")
+		require.Error(t, err)
+		require.Nil(t, ips)
+	})
+
+	t.Run("retrieves nodeID ip addresses", func(t *testing.T) {
+		ips, err := cli.GetIPAddresses(context.Background(), "loadbal-randovalue")
+		require.NoError(t, err)
+		require.NotNil(t, ips)
+
+		require.Len(t, ips.IPAddressableEntities.Entities, 1)
+		require.Len(t, ips.IPAddressableEntities.Entities[0].IPAddresses, 2)
+
+		assert.Equal(t, "ipamipa-8IPzP37YJ1iTxJdMrCods", ips.IPAddressableEntities.Entities[0].IPAddresses[0].ID)
+		assert.Equal(t, "192.168.1.142", ips.IPAddressableEntities.Entities[0].IPAddresses[0].IP)
+		assert.False(t, ips.IPAddressableEntities.Entities[0].IPAddresses[0].Reserved)
+
+		assert.Equal(t, "ipamipa-rPBY83fPw6Ll5sueCMpDr", ips.IPAddressableEntities.Entities[0].IPAddresses[1].ID)
+		assert.Equal(t, "192.168.1.1", ips.IPAddressableEntities.Entities[0].IPAddresses[1].IP)
+		assert.True(t, ips.IPAddressableEntities.Entities[0].IPAddresses[1].Reserved)
+	})
+}
+
+func mustNewGQLTestClient(respJSON string) *graphql.Client {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/query", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, respJSON)
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	return graphql.NewClient("/query", &http.Client{Transport: localRoundTripper{handler: mux}})
+}
+
+type localRoundTripper struct {
+	handler http.Handler
+}
+
+func (l localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	l.handler.ServeHTTP(w, req)
+
+	return w.Result(), nil
 }

--- a/pkg/ipamclient/types.go
+++ b/pkg/ipamclient/types.go
@@ -100,3 +100,21 @@ type DeleteIPAddress struct {
 type DeleteIPAddressResult struct {
 	DeletedID string `graphql:"deletedID"`
 }
+
+// IPAddressableFragment fragment for getting IP Addresses by node
+type IPAddressableFragment struct {
+	IPAddresses []IPAddressNode
+}
+
+// IPAddressableEntities query result for getting IP Addresses by node
+type IPAddressableEntities struct {
+	Entities []struct {
+		ID                    string
+		IPAddressableFragment `graphql:"... on IPAddressable"`
+	} `graphql:"_entities"`
+}
+
+// GetIPAddressesByNode query for getting IP Addresses by node
+type GetIPAddressesByNode struct {
+	IPAddressableEntities `graphql:"_entities(representations: $representations)"`
+}


### PR DESCRIPTION
# Summary

- [x] Adding this query to use in the meantime til supergraph is ready
- [x] Model ipam client structs based on this query/result

```
query GetAddressByNode {
  _entities(representations: $respresentations) {
    ... on IPAddressable {
      id
      IPAddresses {
        id
        ip
        reserved
      }
    }
  }
}

{
  "data": {
    "_entities": [
      {
        "id": "nodeidt-loadbalancer",
        "IPAddresses": [
          {
            "id": "ipamipa-8IPzP37YJ1iTxJdMrCods",
            "ip": "192.168.1.42",
            "reserved": false
          },
          {
            "id": "ipamipa-rPBY83fPw6Ll5sueCMpDr",
            "ip": "192.168.1.1",
            "reserved": true
          }
        ]
      }
    ]
  }
}
```
