### PR TITLE
Fix OIDC environment variable

### DIFF
--- a/chart/ipam-api/templates/api-config.yaml
+++ b/chart/ipam-api/templates/api-config.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   IPAMAPI_EVENTS_PUBLISHER_PREFIX: "{{ .Values.api.events.topicPrefix }}"
   IPAMAPI_EVENTS_PUBLISHER_URL: "{{ .Values.api.events.connectionURL }}"
-  IPAMAPI_OIDC: "{{ .Values.api.oidc.enabled }}"
+  IPAMAPI_OIDC_ENABLED: "{{ .Values.api.oidc.enabled }}"
   IPAMAPI_OIDC_AUDIENCE: "{{ .Values.api.oidc.audience }}"
   IPAMAPI_OIDC_ISSUER: "{{ .Values.api.oidc.issuer }}"
   IPAMAPI_OIDC_JWKS_REMOTE_TIMEOUT: "{{ .Values.api.oidc.jwksRemoteTimeout }}"


### PR DESCRIPTION
Fixes the naming of `IPAMAPI_OIDC` -> `IPAMAPI_OIDC_ENABLED`