### PR TITLE
Update graph names to be camelCase to follow graphql best practices

### DIFF
--- a/internal/graphapi/gen_models.go
+++ b/internal/graphapi/gen_models.go
@@ -10,7 +10,7 @@ import (
 // Return response for createIPAddress mutation
 type IPAddressCreatePayload struct {
 	// Created ip block type
-	IPAddress *generated.IPAddress `json:"ip_address"`
+	IPAddress *generated.IPAddress `json:"ipAddress"`
 }
 
 // Return response for deleteIPAddress mutation
@@ -22,14 +22,14 @@ type IPAddressDeletePayload struct {
 // Return response for updateIPAddress mutation
 type IPAddressUpdatePayload struct {
 	// Updated ip block type
-	IPAddress *generated.IPAddress `json:"ip_address"`
+	IPAddress *generated.IPAddress `json:"ipAddress"`
 }
 
-// IPAddressable provides an interface for describing IP addresses attached to a node
+// IPAddressable provides an interface for determining if a node can have IP addresses attached to it
 type IPAddressable struct {
 	ID gidx.PrefixedID `json:"id"`
-	// IPAddressable describes IP addresses attached to a node
-	IPAddresses []*generated.IPAddress `json:"IPAddresses"`
+	// ipAddresses returns all the ip addresses attached to the node
+	IPAddresses []*generated.IPAddress `json:"ipAddresses"`
 }
 
 func (IPAddressable) IsEntity() {}
@@ -37,7 +37,7 @@ func (IPAddressable) IsEntity() {}
 // Return response for createIPBlock mutation
 type IPBlockCreatePayload struct {
 	// Created ip block type
-	IPBlock *generated.IPBlock `json:"ip_block"`
+	IPBlock *generated.IPBlock `json:"ipBlock"`
 }
 
 // Return response for deleteIPBlock mutation
@@ -49,7 +49,7 @@ type IPBlockDeletePayload struct {
 // Return response for createIPBlockType mutation
 type IPBlockTypeCreatePayload struct {
 	// Created ip block type
-	IPBlockType *generated.IPBlockType `json:"ip_block_type"`
+	IPBlockType *generated.IPBlockType `json:"ipBlockType"`
 }
 
 // Return response for deleteIPBlockType mutation
@@ -61,18 +61,18 @@ type IPBlockTypeDeletePayload struct {
 // Return response for updateIPBlockType mutation
 type IPBlockTypeUpdatePayload struct {
 	// Updated ip block type
-	IPBlockType *generated.IPBlockType `json:"ip_block_type"`
+	IPBlockType *generated.IPBlockType `json:"ipBlockType"`
 }
 
 // Return response for updateIPBlock mutation
 type IPBlockUpdatePayload struct {
 	// Updated ip block type
-	IPBlock *generated.IPBlock `json:"ip_block"`
+	IPBlock *generated.IPBlock `json:"ipBlock"`
 }
 
 type ResourceOwner struct {
 	ID          gidx.PrefixedID                  `json:"id"`
-	IPBlockType *generated.IPBlockTypeConnection `json:"ip_block_type"`
+	IPBlockType *generated.IPBlockTypeConnection `json:"ipBlockType"`
 }
 
 func (ResourceOwner) IsEntity() {}

--- a/internal/graphapi/generated.go
+++ b/internal/graphapi/generated.go
@@ -384,7 +384,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPAddressConnection.TotalCount(childComplexity), true
 
-	case "IPAddressCreatePayload.ip_address":
+	case "IPAddressCreatePayload.ipAddress":
 		if e.complexity.IPAddressCreatePayload.IPAddress == nil {
 			break
 		}
@@ -412,7 +412,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPAddressEdge.Node(childComplexity), true
 
-	case "IPAddressUpdatePayload.ip_address":
+	case "IPAddressUpdatePayload.ipAddress":
 		if e.complexity.IPAddressUpdatePayload.IPAddress == nil {
 			break
 		}
@@ -426,7 +426,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPAddressable.ID(childComplexity), true
 
-	case "IPAddressable.IPAddresses":
+	case "IPAddressable.ipAddresses":
 		if e.complexity.IPAddressable.IPAddresses == nil {
 			break
 		}
@@ -515,7 +515,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPBlockConnection.TotalCount(childComplexity), true
 
-	case "IPBlockCreatePayload.ip_block":
+	case "IPBlockCreatePayload.ipBlock":
 		if e.complexity.IPBlockCreatePayload.IPBlock == nil {
 			break
 		}
@@ -611,7 +611,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPBlockTypeConnection.TotalCount(childComplexity), true
 
-	case "IPBlockTypeCreatePayload.ip_block_type":
+	case "IPBlockTypeCreatePayload.ipBlockType":
 		if e.complexity.IPBlockTypeCreatePayload.IPBlockType == nil {
 			break
 		}
@@ -639,14 +639,14 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPBlockTypeEdge.Node(childComplexity), true
 
-	case "IPBlockTypeUpdatePayload.ip_block_type":
+	case "IPBlockTypeUpdatePayload.ipBlockType":
 		if e.complexity.IPBlockTypeUpdatePayload.IPBlockType == nil {
 			break
 		}
 
 		return e.complexity.IPBlockTypeUpdatePayload.IPBlockType(childComplexity), true
 
-	case "IPBlockUpdatePayload.ip_block":
+	case "IPBlockUpdatePayload.ipBlock":
 		if e.complexity.IPBlockUpdatePayload.IPBlock == nil {
 			break
 		}
@@ -789,36 +789,36 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PageInfo.StartCursor(childComplexity), true
 
-	case "Query.ip_address":
+	case "Query.ipAddress":
 		if e.complexity.Query.IPAddress == nil {
 			break
 		}
 
-		args, err := ec.field_Query_ip_address_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_ipAddress_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
 		return e.complexity.Query.IPAddress(childComplexity, args["id"].(gidx.PrefixedID)), true
 
-	case "Query.ip_block":
+	case "Query.ipBlock":
 		if e.complexity.Query.IPBlock == nil {
 			break
 		}
 
-		args, err := ec.field_Query_ip_block_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_ipBlock_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
 		return e.complexity.Query.IPBlock(childComplexity, args["id"].(gidx.PrefixedID)), true
 
-	case "Query.ip_block_type":
+	case "Query.ipBlockType":
 		if e.complexity.Query.IPBlockType == nil {
 			break
 		}
 
-		args, err := ec.field_Query_ip_block_type_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_ipBlockType_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
@@ -851,12 +851,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ResourceOwner.ID(childComplexity), true
 
-	case "ResourceOwner.ip_block_type":
+	case "ResourceOwner.ipBlockType":
 		if e.complexity.ResourceOwner.IPBlockType == nil {
 			break
 		}
 
-		args, err := ec.field_ResourceOwner_ip_block_type_args(context.TODO(), rawArgs)
+		args, err := ec.field_ResourceOwner_ipBlockType_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
@@ -1425,79 +1425,71 @@ input UpdateIPBlockTypeInput {
 }
 `, BuiltIn: false},
 	{Name: "../../schema/ipaddress.graphql", Input: `extend type Query {
+  """
+  Look up ip block type by ID
+  """
+  ipAddress(
     """
-    Look up ip block type by ID
+    ID of the ip block type
     """
-    ip_address(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPAddress!
+    id: ID!
+  ): IPAddress!
 }
 
-extend type Mutation{
+extend type Mutation {
+  """
+  Create a new ip address
+  """
+  createIPAddress(input: CreateIPAddressInput!): IPAddressCreatePayload!
+  """
+  Update an existing ip block type
+  """
+  updateIPAddress(
     """
-    Create a new ip block type
+    ID of the ip address to update
     """
-    createIPAddress(
-        """
-        Name of the ip block type
-        """
-        input: CreateIPAddressInput!
-    ): IPAddressCreatePayload!
+    id: ID!
+    input: UpdateIPAddressInput!
+  ): IPAddressUpdatePayload!
+  """
+  Delete an existing ip block type
+  """
+  deleteIPAddress(
     """
-    Update an existing ip block type
+    ID of the ip address
     """
-    updateIPAddress(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-        """
-        Name of the ip block type
-        """
-        input: UpdateIPAddressInput!
-    ): IPAddressUpdatePayload!
-    """
-    Delete an existing ip block type
-    """
-    deleteIPAddress(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPAddressDeletePayload!
+    id: ID!
+  ): IPAddressDeletePayload!
 }
 
 """
 Return response for createIPAddress mutation
 """
 type IPAddressCreatePayload {
-    """
-    Created ip block type
-    """
-    ip_address: IPAddress!
+  """
+  Created ip block type
+  """
+  ipAddress: IPAddress!
 }
 
 """
 Return response for updateIPAddress mutation
 """
 type IPAddressUpdatePayload {
-    """
-    Updated ip block type
-    """
-    ip_address: IPAddress!
+  """
+  Updated ip block type
+  """
+  ipAddress: IPAddress!
 }
 
 """
 Return response for deleteIPAddress mutation
 """
 type IPAddressDeletePayload {
-    """
-    Deleted ip block type
-    """
-    deletedID: ID!
+  """
+  Deleted ip block type
+  """
+  deletedID: ID!
 }
 
 extend schema
@@ -1507,179 +1499,177 @@ extend schema
   )
 
 """
-IPAddressable provides an interface for describing IP addresses attached to a node
+IPAddressable provides an interface for determining if a node can have IP addresses attached to it
 """
 type IPAddressable @key(fields: "id") @interfaceObject {
   id: ID!
   """
-  IPAddressable describes IP addresses attached to a node
+  ipAddresses returns all the ip addresses attached to the node
   """
-  IPAddresses: [IPAddress]! @goField(forceResolver: true)
+  ipAddresses: [IPAddress]! @goField(forceResolver: true)
 }
 
 extend type IPAddress {
   """
-  IPAddresses that are associated with a given node
+  node the ip address is attached to
   """
   node: IPAddressable!
-}`, BuiltIn: false},
+}
+`, BuiltIn: false},
 	{Name: "../../schema/ipblock.graphql", Input: `extend type Query {
+  """
+  Look up ip block type by ID
+  """
+  ipBlock(
     """
-    Look up ip block type by ID
+    ID of the ip block type
     """
-    ip_block(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlock!
+    id: ID!
+  ): IPBlock!
 }
 
-extend type Mutation{
+extend type Mutation {
+  """
+  Create a new ip block type
+  """
+  createIPBlock(
     """
-    Create a new ip block type
+    Name of the ip block type
     """
-    createIPBlock(
-        """
-        Name of the ip block type
-        """
-        input: CreateIPBlockInput!
-    ): IPBlockCreatePayload!
+    input: CreateIPBlockInput!
+  ): IPBlockCreatePayload!
+  """
+  Update an existing ip block type
+  """
+  updateIPBlock(
     """
-    Update an existing ip block type
+    ID of the ip block type
     """
-    updateIPBlock(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-        """
-        Name of the ip block type
-        """
-        input: UpdateIPBlockInput!
-    ): IPBlockUpdatePayload!
+    id: ID!
+    input: UpdateIPBlockInput!
+  ): IPBlockUpdatePayload!
+  """
+  Delete an existing ip block type
+  """
+  deleteIPBlock(
     """
-    Delete an existing ip block type
+    ID of the ip block type
     """
-    deleteIPBlock(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlockDeletePayload!
+    id: ID!
+  ): IPBlockDeletePayload!
 }
 
 """
 Return response for createIPBlock mutation
 """
 type IPBlockCreatePayload {
-    """
-    Created ip block type
-    """
-    ip_block: IPBlock!
+  """
+  Created ip block type
+  """
+  ipBlock: IPBlock!
 }
 
 """
 Return response for updateIPBlock mutation
 """
 type IPBlockUpdatePayload {
-    """
-    Updated ip block type
-    """
-    ip_block: IPBlock!
+  """
+  Updated ip block type
+  """
+  ipBlock: IPBlock!
 }
 
 """
 Return response for deleteIPBlock mutation
 """
 type IPBlockDeletePayload {
-    """
-    Deleted ip block type
-    """
-    deletedID: ID!
+  """
+  Deleted ip block type
+  """
+  deletedID: ID!
 }
 `, BuiltIn: false},
 	{Name: "../../schema/ipblocktype.graphql", Input: `extend type Query {
+  """
+  Look up ip block type by ID
+  """
+  ipBlockType(
     """
-    Look up ip block type by ID
+    ID of the ip block type
     """
-    ip_block_type(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlockType!
+    id: ID!
+  ): IPBlockType!
 }
 
-extend type Mutation{
+extend type Mutation {
+  """
+  Create a new ip block type
+  """
+  createIPBlockType(
     """
-    Create a new ip block type
+    Name of the ip block type
     """
-    createIPBlockType(
-        """
-        Name of the ip block type
-        """
-        input: CreateIPBlockTypeInput!
-    ): IPBlockTypeCreatePayload!
+    input: CreateIPBlockTypeInput!
+  ): IPBlockTypeCreatePayload!
+  """
+  Update an existing ip block type
+  """
+  updateIPBlockType(
     """
-    Update an existing ip block type
+    ID of the ip block type
     """
-    updateIPBlockType(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-        """
-        Name of the ip block type
-        """
-        input: UpdateIPBlockTypeInput!
-    ): IPBlockTypeUpdatePayload!
+    id: ID!
     """
-    Delete an existing ip block type
+    Name of the ip block type
     """
-    deleteIPBlockType(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlockTypeDeletePayload!
+    input: UpdateIPBlockTypeInput!
+  ): IPBlockTypeUpdatePayload!
+  """
+  Delete an existing ip block type
+  """
+  deleteIPBlockType(
+    """
+    ID of the ip block type
+    """
+    id: ID!
+  ): IPBlockTypeDeletePayload!
 }
 
 """
 Return response for createIPBlockType mutation
 """
 type IPBlockTypeCreatePayload {
-    """
-    Created ip block type
-    """
-    ip_block_type: IPBlockType!
+  """
+  Created ip block type
+  """
+  ipBlockType: IPBlockType!
 }
 
 """
 Return response for updateIPBlockType mutation
 """
 type IPBlockTypeUpdatePayload {
-    """
-    Updated ip block type
-    """
-    ip_block_type: IPBlockType!
+  """
+  Updated ip block type
+  """
+  ipBlockType: IPBlockType!
 }
 
 """
 Return response for deleteIPBlockType mutation
 """
 type IPBlockTypeDeletePayload {
-    """
-    Deleted ip block type
-    """
-    deletedID: ID!
+  """
+  Deleted ip block type
+  """
+  deletedID: ID!
 }
 `, BuiltIn: false},
 	{Name: "../../schema/owner.graphql", Input: `directive @prefixedID(prefix: String!) on OBJECT
 
 type ResourceOwner @key(fields: "id") @interfaceObject {
   id: ID!
-  ip_block_type(
+  ipBlockType(
     """
     Returns the elements in the list that come after the specified cursor.
     """
@@ -2187,7 +2177,7 @@ func (ec *executionContext) field_Query__entities_args(ctx context.Context, rawA
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_ip_address_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_ipAddress_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 gidx.PrefixedID
@@ -2202,7 +2192,7 @@ func (ec *executionContext) field_Query_ip_address_args(ctx context.Context, raw
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_ip_block_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_ipBlockType_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 gidx.PrefixedID
@@ -2217,7 +2207,7 @@ func (ec *executionContext) field_Query_ip_block_args(ctx context.Context, rawAr
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_ip_block_type_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_ipBlock_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 gidx.PrefixedID
@@ -2232,7 +2222,7 @@ func (ec *executionContext) field_Query_ip_block_type_args(ctx context.Context, 
 	return args, nil
 }
 
-func (ec *executionContext) field_ResourceOwner_ip_block_type_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_ResourceOwner_ipBlockType_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 *entgql.Cursor[gidx.PrefixedID]
@@ -2442,8 +2432,8 @@ func (ec *executionContext) fieldContext_Entity_findIPAddressableByID(ctx contex
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_IPAddressable_id(ctx, field)
-			case "IPAddresses":
-				return ec.fieldContext_IPAddressable_IPAddresses(ctx, field)
+			case "ipAddresses":
+				return ec.fieldContext_IPAddressable_ipAddresses(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPAddressable", field.Name)
 		},
@@ -2645,8 +2635,8 @@ func (ec *executionContext) fieldContext_Entity_findResourceOwnerByID(ctx contex
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ResourceOwner_id(ctx, field)
-			case "ip_block_type":
-				return ec.fieldContext_ResourceOwner_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_ResourceOwner_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ResourceOwner", field.Name)
 		},
@@ -2988,8 +2978,8 @@ func (ec *executionContext) fieldContext_IPAddress_node(ctx context.Context, fie
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_IPAddressable_id(ctx, field)
-			case "IPAddresses":
-				return ec.fieldContext_IPAddressable_IPAddresses(ctx, field)
+			case "ipAddresses":
+				return ec.fieldContext_IPAddressable_ipAddresses(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPAddressable", field.Name)
 		},
@@ -3142,8 +3132,8 @@ func (ec *executionContext) fieldContext_IPAddressConnection_totalCount(ctx cont
 	return fc, nil
 }
 
-func (ec *executionContext) _IPAddressCreatePayload_ip_address(ctx context.Context, field graphql.CollectedField, obj *IPAddressCreatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPAddressCreatePayload_ip_address(ctx, field)
+func (ec *executionContext) _IPAddressCreatePayload_ipAddress(ctx context.Context, field graphql.CollectedField, obj *IPAddressCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPAddressCreatePayload_ipAddress(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3173,7 +3163,7 @@ func (ec *executionContext) _IPAddressCreatePayload_ip_address(ctx context.Conte
 	return ec.marshalNIPAddress2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPAddressCreatePayload_ip_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPAddressCreatePayload_ipAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPAddressCreatePayload",
 		Field:      field,
@@ -3347,8 +3337,8 @@ func (ec *executionContext) fieldContext_IPAddressEdge_cursor(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _IPAddressUpdatePayload_ip_address(ctx context.Context, field graphql.CollectedField, obj *IPAddressUpdatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPAddressUpdatePayload_ip_address(ctx, field)
+func (ec *executionContext) _IPAddressUpdatePayload_ipAddress(ctx context.Context, field graphql.CollectedField, obj *IPAddressUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPAddressUpdatePayload_ipAddress(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3378,7 +3368,7 @@ func (ec *executionContext) _IPAddressUpdatePayload_ip_address(ctx context.Conte
 	return ec.marshalNIPAddress2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPAddressUpdatePayload_ip_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPAddressUpdatePayload_ipAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPAddressUpdatePayload",
 		Field:      field,
@@ -3451,8 +3441,8 @@ func (ec *executionContext) fieldContext_IPAddressable_id(ctx context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _IPAddressable_IPAddresses(ctx context.Context, field graphql.CollectedField, obj *IPAddressable) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPAddressable_IPAddresses(ctx, field)
+func (ec *executionContext) _IPAddressable_ipAddresses(ctx context.Context, field graphql.CollectedField, obj *IPAddressable) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPAddressable_ipAddresses(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3482,7 +3472,7 @@ func (ec *executionContext) _IPAddressable_IPAddresses(ctx context.Context, fiel
 	return ec.marshalNIPAddress2ᚕᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPAddressable_IPAddresses(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPAddressable_ipAddresses(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPAddressable",
 		Field:      field,
@@ -4041,8 +4031,8 @@ func (ec *executionContext) fieldContext_IPBlockConnection_totalCount(ctx contex
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockCreatePayload_ip_block(ctx context.Context, field graphql.CollectedField, obj *IPBlockCreatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockCreatePayload_ip_block(ctx, field)
+func (ec *executionContext) _IPBlockCreatePayload_ipBlock(ctx context.Context, field graphql.CollectedField, obj *IPBlockCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockCreatePayload_ipBlock(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4072,7 +4062,7 @@ func (ec *executionContext) _IPBlockCreatePayload_ip_block(ctx context.Context, 
 	return ec.marshalNIPBlock2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlock(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockCreatePayload_ip_block(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockCreatePayload_ipBlock(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockCreatePayload",
 		Field:      field,
@@ -4530,8 +4520,8 @@ func (ec *executionContext) fieldContext_IPBlockType_owner(ctx context.Context, 
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ResourceOwner_id(ctx, field)
-			case "ip_block_type":
-				return ec.fieldContext_ResourceOwner_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_ResourceOwner_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ResourceOwner", field.Name)
 		},
@@ -4684,8 +4674,8 @@ func (ec *executionContext) fieldContext_IPBlockTypeConnection_totalCount(ctx co
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockTypeCreatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeCreatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockTypeCreatePayload_ip_block_type(ctx, field)
+func (ec *executionContext) _IPBlockTypeCreatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockTypeCreatePayload_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4715,7 +4705,7 @@ func (ec *executionContext) _IPBlockTypeCreatePayload_ip_block_type(ctx context.
 	return ec.marshalNIPBlockType2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockTypeCreatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockTypeCreatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockTypeCreatePayload",
 		Field:      field,
@@ -4885,8 +4875,8 @@ func (ec *executionContext) fieldContext_IPBlockTypeEdge_cursor(ctx context.Cont
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockTypeUpdatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeUpdatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockTypeUpdatePayload_ip_block_type(ctx, field)
+func (ec *executionContext) _IPBlockTypeUpdatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockTypeUpdatePayload_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4916,7 +4906,7 @@ func (ec *executionContext) _IPBlockTypeUpdatePayload_ip_block_type(ctx context.
 	return ec.marshalNIPBlockType2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockTypeUpdatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockTypeUpdatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockTypeUpdatePayload",
 		Field:      field,
@@ -4943,8 +4933,8 @@ func (ec *executionContext) fieldContext_IPBlockTypeUpdatePayload_ip_block_type(
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockUpdatePayload_ip_block(ctx context.Context, field graphql.CollectedField, obj *IPBlockUpdatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockUpdatePayload_ip_block(ctx, field)
+func (ec *executionContext) _IPBlockUpdatePayload_ipBlock(ctx context.Context, field graphql.CollectedField, obj *IPBlockUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockUpdatePayload_ipBlock(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4974,7 +4964,7 @@ func (ec *executionContext) _IPBlockUpdatePayload_ip_block(ctx context.Context, 
 	return ec.marshalNIPBlock2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlock(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockUpdatePayload_ip_block(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockUpdatePayload_ipBlock(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockUpdatePayload",
 		Field:      field,
@@ -5044,8 +5034,8 @@ func (ec *executionContext) fieldContext_Mutation_createIPAddress(ctx context.Co
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_address":
-				return ec.fieldContext_IPAddressCreatePayload_ip_address(ctx, field)
+			case "ipAddress":
+				return ec.fieldContext_IPAddressCreatePayload_ipAddress(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPAddressCreatePayload", field.Name)
 		},
@@ -5103,8 +5093,8 @@ func (ec *executionContext) fieldContext_Mutation_updateIPAddress(ctx context.Co
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_address":
-				return ec.fieldContext_IPAddressUpdatePayload_ip_address(ctx, field)
+			case "ipAddress":
+				return ec.fieldContext_IPAddressUpdatePayload_ipAddress(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPAddressUpdatePayload", field.Name)
 		},
@@ -5221,8 +5211,8 @@ func (ec *executionContext) fieldContext_Mutation_createIPBlock(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block":
-				return ec.fieldContext_IPBlockCreatePayload_ip_block(ctx, field)
+			case "ipBlock":
+				return ec.fieldContext_IPBlockCreatePayload_ipBlock(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockCreatePayload", field.Name)
 		},
@@ -5280,8 +5270,8 @@ func (ec *executionContext) fieldContext_Mutation_updateIPBlock(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block":
-				return ec.fieldContext_IPBlockUpdatePayload_ip_block(ctx, field)
+			case "ipBlock":
+				return ec.fieldContext_IPBlockUpdatePayload_ipBlock(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockUpdatePayload", field.Name)
 		},
@@ -5398,8 +5388,8 @@ func (ec *executionContext) fieldContext_Mutation_createIPBlockType(ctx context.
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block_type":
-				return ec.fieldContext_IPBlockTypeCreatePayload_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_IPBlockTypeCreatePayload_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockTypeCreatePayload", field.Name)
 		},
@@ -5457,8 +5447,8 @@ func (ec *executionContext) fieldContext_Mutation_updateIPBlockType(ctx context.
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block_type":
-				return ec.fieldContext_IPBlockTypeUpdatePayload_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_IPBlockTypeUpdatePayload_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockTypeUpdatePayload", field.Name)
 		},
@@ -5706,8 +5696,8 @@ func (ec *executionContext) fieldContext_PageInfo_endCursor(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_ip_address(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_ip_address(ctx, field)
+func (ec *executionContext) _Query_ipAddress(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ipAddress(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -5737,7 +5727,7 @@ func (ec *executionContext) _Query_ip_address(ctx context.Context, field graphql
 	return ec.marshalNIPAddress2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_ip_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_ipAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5770,15 +5760,15 @@ func (ec *executionContext) fieldContext_Query_ip_address(ctx context.Context, f
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_ip_address_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_ipAddress_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_ip_block(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_ip_block(ctx, field)
+func (ec *executionContext) _Query_ipBlock(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ipBlock(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -5808,7 +5798,7 @@ func (ec *executionContext) _Query_ip_block(ctx context.Context, field graphql.C
 	return ec.marshalNIPBlock2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlock(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_ip_block(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_ipBlock(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5843,15 +5833,15 @@ func (ec *executionContext) fieldContext_Query_ip_block(ctx context.Context, fie
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_ip_block_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_ipBlock_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_ip_block_type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_ip_block_type(ctx, field)
+func (ec *executionContext) _Query_ipBlockType(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -5881,7 +5871,7 @@ func (ec *executionContext) _Query_ip_block_type(ctx context.Context, field grap
 	return ec.marshalNIPBlockType2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5912,7 +5902,7 @@ func (ec *executionContext) fieldContext_Query_ip_block_type(ctx context.Context
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_ip_block_type_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_ipBlockType_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -6195,8 +6185,8 @@ func (ec *executionContext) fieldContext_ResourceOwner_id(ctx context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _ResourceOwner_ip_block_type(ctx context.Context, field graphql.CollectedField, obj *ResourceOwner) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ResourceOwner_ip_block_type(ctx, field)
+func (ec *executionContext) _ResourceOwner_ipBlockType(ctx context.Context, field graphql.CollectedField, obj *ResourceOwner) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ResourceOwner_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -6226,7 +6216,7 @@ func (ec *executionContext) _ResourceOwner_ip_block_type(ctx context.Context, fi
 	return ec.marshalNIPBlockTypeConnection2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockTypeConnection(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_ResourceOwner_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_ResourceOwner_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ResourceOwner",
 		Field:      field,
@@ -6251,7 +6241,7 @@ func (ec *executionContext) fieldContext_ResourceOwner_ip_block_type(ctx context
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_ResourceOwner_ip_block_type_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_ResourceOwner_ipBlockType_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -10171,8 +10161,8 @@ func (ec *executionContext) _IPAddressCreatePayload(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPAddressCreatePayload")
-		case "ip_address":
-			out.Values[i] = ec._IPAddressCreatePayload_ip_address(ctx, field, obj)
+		case "ipAddress":
+			out.Values[i] = ec._IPAddressCreatePayload_ipAddress(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10290,8 +10280,8 @@ func (ec *executionContext) _IPAddressUpdatePayload(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPAddressUpdatePayload")
-		case "ip_address":
-			out.Values[i] = ec._IPAddressUpdatePayload_ip_address(ctx, field, obj)
+		case "ipAddress":
+			out.Values[i] = ec._IPAddressUpdatePayload_ipAddress(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10334,7 +10324,7 @@ func (ec *executionContext) _IPAddressable(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "IPAddresses":
+		case "ipAddresses":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -10343,7 +10333,7 @@ func (ec *executionContext) _IPAddressable(ctx context.Context, sel ast.Selectio
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._IPAddressable_IPAddresses(ctx, field, obj)
+				res = ec._IPAddressable_ipAddresses(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -10586,8 +10576,8 @@ func (ec *executionContext) _IPBlockCreatePayload(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockCreatePayload")
-		case "ip_block":
-			out.Values[i] = ec._IPBlockCreatePayload_ip_block(ctx, field, obj)
+		case "ipBlock":
+			out.Values[i] = ec._IPBlockCreatePayload_ipBlock(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10877,8 +10867,8 @@ func (ec *executionContext) _IPBlockTypeCreatePayload(ctx context.Context, sel a
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockTypeCreatePayload")
-		case "ip_block_type":
-			out.Values[i] = ec._IPBlockTypeCreatePayload_ip_block_type(ctx, field, obj)
+		case "ipBlockType":
+			out.Values[i] = ec._IPBlockTypeCreatePayload_ipBlockType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10996,8 +10986,8 @@ func (ec *executionContext) _IPBlockTypeUpdatePayload(ctx context.Context, sel a
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockTypeUpdatePayload")
-		case "ip_block_type":
-			out.Values[i] = ec._IPBlockTypeUpdatePayload_ip_block_type(ctx, field, obj)
+		case "ipBlockType":
+			out.Values[i] = ec._IPBlockTypeUpdatePayload_ipBlockType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -11035,8 +11025,8 @@ func (ec *executionContext) _IPBlockUpdatePayload(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockUpdatePayload")
-		case "ip_block":
-			out.Values[i] = ec._IPBlockUpdatePayload_ip_block(ctx, field, obj)
+		case "ipBlock":
+			out.Values[i] = ec._IPBlockUpdatePayload_ipBlock(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -11235,7 +11225,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Query")
-		case "ip_address":
+		case "ipAddress":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11244,7 +11234,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_ip_address(ctx, field)
+				res = ec._Query_ipAddress(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11257,7 +11247,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "ip_block":
+		case "ipBlock":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11266,7 +11256,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_ip_block(ctx, field)
+				res = ec._Query_ipBlock(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11279,7 +11269,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "ip_block_type":
+		case "ipBlockType":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11288,7 +11278,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_ip_block_type(ctx, field)
+				res = ec._Query_ipBlockType(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11392,7 +11382,7 @@ func (ec *executionContext) _ResourceOwner(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "ip_block_type":
+		case "ipBlockType":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11401,7 +11391,7 @@ func (ec *executionContext) _ResourceOwner(ctx context.Context, sel ast.Selectio
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._ResourceOwner_ip_block_type(ctx, field, obj)
+				res = ec._ResourceOwner_ipBlockType(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/testclient/gen_client.go
+++ b/internal/testclient/gen_client.go
@@ -37,9 +37,9 @@ func NewClient(cli *http.Client, baseURL string, options ...client.HTTPRequestOp
 }
 
 type Query struct {
-	IPAddress   IPAddress   "json:\"ip_address\" graphql:\"ip_address\""
-	IPBlock     IPBlock     "json:\"ip_block\" graphql:\"ip_block\""
-	IPBlockType IPBlockType "json:\"ip_block_type\" graphql:\"ip_block_type\""
+	IPAddress   IPAddress   "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPBlock     IPBlock     "json:\"ipBlock\" graphql:\"ipBlock\""
+	IPBlockType IPBlockType "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	Entities    []Entity    "json:\"_entities\" graphql:\"_entities\""
 	Service     Service     "json:\"_service\" graphql:\"_service\""
 }
@@ -71,7 +71,7 @@ type CreateIPAddress struct {
 					} "json:\"edges\" graphql:\"edges\""
 				} "json:\"ipAddress\" graphql:\"ipAddress\""
 			} "json:\"ipBlock\" graphql:\"ipBlock\""
-		} "json:\"ip_address\" graphql:\"ip_address\""
+		} "json:\"ipAddress\" graphql:\"ipAddress\""
 	} "json:\"createIPAddress\" graphql:\"createIPAddress\""
 }
 type DeleteIPAddress struct {
@@ -83,7 +83,7 @@ type GetIPAddressesByNode struct {
 	Entities []*struct {
 		IPAddresses []*struct {
 			IP string "json:\"ip\" graphql:\"ip\""
-		} "json:\"IPAddresses\" graphql:\"IPAddresses\""
+		} "json:\"ipAddresses\" graphql:\"ipAddresses\""
 	} "json:\"_entities\" graphql:\"_entities\""
 }
 type GetIPBlock struct {
@@ -104,7 +104,7 @@ type GetIPBlock struct {
 				} "json:\"node\" graphql:\"node\""
 			} "json:\"edges\" graphql:\"edges\""
 		} "json:\"ipAddress\" graphql:\"ipAddress\""
-	} "json:\"ip_block\" graphql:\"ip_block\""
+	} "json:\"ipBlock\" graphql:\"ipBlock\""
 }
 type GetIPBlockType struct {
 	IPBlockType struct {
@@ -115,7 +115,7 @@ type GetIPBlockType struct {
 		} "json:\"owner\" graphql:\"owner\""
 		CreatedAt time.Time "json:\"createdAt\" graphql:\"createdAt\""
 		UpdatedAt time.Time "json:\"updatedAt\" graphql:\"updatedAt\""
-	} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+	} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 }
 type IPBlockCreate struct {
 	CreateIPBlock struct {
@@ -136,7 +136,7 @@ type IPBlockCreate struct {
 					} "json:\"node\" graphql:\"node\""
 				} "json:\"edges\" graphql:\"edges\""
 			} "json:\"ipAddress\" graphql:\"ipAddress\""
-		} "json:\"ip_block\" graphql:\"ip_block\""
+		} "json:\"ipBlock\" graphql:\"ipBlock\""
 	} "json:\"createIPBlock\" graphql:\"createIPBlock\""
 }
 type IPBlockDelete struct {
@@ -154,7 +154,7 @@ type IPBlockTypeCreate struct {
 			} "json:\"owner\" graphql:\"owner\""
 			CreatedAt time.Time "json:\"createdAt\" graphql:\"createdAt\""
 			UpdatedAt time.Time "json:\"updatedAt\" graphql:\"updatedAt\""
-		} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+		} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	} "json:\"createIPBlockType\" graphql:\"createIPBlockType\""
 }
 type IPBlockTypeDelete struct {
@@ -169,7 +169,7 @@ type IPBlockTypeUpdate struct {
 			Name      string          "json:\"name\" graphql:\"name\""
 			CreatedAt time.Time       "json:\"createdAt\" graphql:\"createdAt\""
 			UpdatedAt time.Time       "json:\"updatedAt\" graphql:\"updatedAt\""
-		} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+		} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	} "json:\"updateIPBlockType\" graphql:\"updateIPBlockType\""
 }
 type IPBlockUpdate struct {
@@ -191,7 +191,7 @@ type IPBlockUpdate struct {
 					} "json:\"node\" graphql:\"node\""
 				} "json:\"edges\" graphql:\"edges\""
 			} "json:\"ipAddress\" graphql:\"ipAddress\""
-		} "json:\"ip_block\" graphql:\"ip_block\""
+		} "json:\"ipBlock\" graphql:\"ipBlock\""
 	} "json:\"updateIPBlock\" graphql:\"updateIPBlock\""
 }
 type ListIPBlockTypes struct {
@@ -203,7 +203,7 @@ type ListIPBlockTypes struct {
 					Name string          "json:\"name\" graphql:\"name\""
 				} "json:\"node\" graphql:\"node\""
 			} "json:\"edges\" graphql:\"edges\""
-		} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+		} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	} "json:\"_entities\" graphql:\"_entities\""
 }
 type UpdateIPAddress struct {
@@ -223,7 +223,7 @@ type UpdateIPAddress struct {
 					} "json:\"edges\" graphql:\"edges\""
 				} "json:\"ipAddress\" graphql:\"ipAddress\""
 			} "json:\"ipBlock\" graphql:\"ipBlock\""
-		} "json:\"ip_address\" graphql:\"ip_address\""
+		} "json:\"ipAddress\" graphql:\"ipAddress\""
 	} "json:\"updateIPAddress\" graphql:\"updateIPAddress\""
 }
 type GetIPAddress struct {
@@ -237,12 +237,12 @@ type GetIPAddress struct {
 			AllowAutoAllocate bool            "json:\"allowAutoAllocate\" graphql:\"allowAutoAllocate\""
 			AllowAutoSubnet   bool            "json:\"allowAutoSubnet\" graphql:\"allowAutoSubnet\""
 		} "json:\"ipBlock\" graphql:\"ipBlock\""
-	} "json:\"ip_address\" graphql:\"ip_address\""
+	} "json:\"ipAddress\" graphql:\"ipAddress\""
 }
 
 const CreateIPAddressDocument = `mutation CreateIPAddress ($input: CreateIPAddressInput!) {
 	createIPAddress(input: $input) {
-		ip_address {
+		ipAddress {
 			id
 			ip
 			reserved
@@ -298,7 +298,7 @@ func (c *Client) DeleteIPAddress(ctx context.Context, id gidx.PrefixedID, httpRe
 const GetIPAddressesByNodeDocument = `query GetIPAddressesByNode ($id: ID!) {
 	_entities(representations: {__typename:"IPAddressable",id:$id}) {
 		... on IPAddressable {
-			IPAddresses {
+			ipAddresses {
 				ip
 			}
 		}
@@ -320,7 +320,7 @@ func (c *Client) GetIPAddressesByNode(ctx context.Context, id gidx.PrefixedID, h
 }
 
 const GetIPBlockDocument = `query GetIPBlock ($id: ID!) {
-	ip_block(id: $id) {
+	ipBlock(id: $id) {
 		id
 		prefix
 		allowAutoSubnet
@@ -355,7 +355,7 @@ func (c *Client) GetIPBlock(ctx context.Context, id gidx.PrefixedID, httpRequest
 }
 
 const GetIPBlockTypeDocument = `query GetIPBlockType ($id: ID!) {
-	ip_block_type(id: $id) {
+	ipBlockType(id: $id) {
 		id
 		name
 		owner {
@@ -382,7 +382,7 @@ func (c *Client) GetIPBlockType(ctx context.Context, id gidx.PrefixedID, httpReq
 
 const IPBlockCreateDocument = `mutation IPBlockCreate ($input: CreateIPBlockInput!) {
 	createIPBlock(input: $input) {
-		ip_block {
+		ipBlock {
 			id
 			prefix
 			allowAutoSubnet
@@ -439,7 +439,7 @@ func (c *Client) IPBlockDelete(ctx context.Context, id gidx.PrefixedID, httpRequ
 
 const IPBlockTypeCreateDocument = `mutation IPBlockTypeCreate ($input: CreateIPBlockTypeInput!) {
 	createIPBlockType(input: $input) {
-		ip_block_type {
+		ipBlockType {
 			id
 			name
 			owner {
@@ -487,7 +487,7 @@ func (c *Client) IPBlockTypeDelete(ctx context.Context, id gidx.PrefixedID, http
 
 const IPBlockTypeUpdateDocument = `mutation IPBlockTypeUpdate ($id: ID!, $input: UpdateIPBlockTypeInput!) {
 	updateIPBlockType(id: $id, input: $input) {
-		ip_block_type {
+		ipBlockType {
 			id
 			name
 			createdAt
@@ -513,7 +513,7 @@ func (c *Client) IPBlockTypeUpdate(ctx context.Context, id gidx.PrefixedID, inpu
 
 const IPBlockUpdateDocument = `mutation IPBlockUpdate ($id: ID!, $input: UpdateIPBlockInput!) {
 	updateIPBlock(id: $id, input: $input) {
-		ip_block {
+		ipBlock {
 			id
 			prefix
 			allowAutoSubnet
@@ -552,7 +552,7 @@ func (c *Client) IPBlockUpdate(ctx context.Context, id gidx.PrefixedID, input Up
 const ListIPBlockTypesDocument = `query ListIPBlockTypes ($id: ID!, $orderBy: IPBlockTypeOrder) {
 	_entities(representations: [{__typename:"ResourceOwner",id:$id}]) {
 		... on ResourceOwner {
-			ip_block_type(orderBy: $orderBy) {
+			ipBlockType(orderBy: $orderBy) {
 				edges {
 					node {
 						id
@@ -581,7 +581,7 @@ func (c *Client) ListIPBlockTypes(ctx context.Context, id gidx.PrefixedID, order
 
 const UpdateIPAddressDocument = `mutation UpdateIPAddress ($id: ID!, $input: UpdateIPAddressInput!) {
 	updateIPAddress(id: $id, input: $input) {
-		ip_address {
+		ipAddress {
 			id
 			ip
 			reserved
@@ -616,7 +616,7 @@ func (c *Client) UpdateIPAddress(ctx context.Context, id gidx.PrefixedID, input 
 }
 
 const GetIPAddressDocument = `query getIPAddress ($id: ID!) {
-	ip_address(id: $id) {
+	ipAddress(id: $id) {
 		id
 		ip
 		reserved

--- a/internal/testclient/gen_models.go
+++ b/internal/testclient/gen_models.go
@@ -69,7 +69,7 @@ type IPAddress struct {
 	// Reserve the IP without it being assigned.
 	Reserved bool    `json:"reserved"`
 	IPBlock  IPBlock `json:"ipBlock"`
-	// IPAddresses that are associated with a given node
+	// node the ip address is attached to
 	Node IPAddressable `json:"node"`
 }
 
@@ -93,7 +93,7 @@ type IPAddressConnection struct {
 // Return response for createIPAddress mutation
 type IPAddressCreatePayload struct {
 	// Created ip block type
-	IPAddress IPAddress `json:"ip_address"`
+	IPAddress IPAddress `json:"ipAddress"`
 }
 
 // Return response for deleteIPAddress mutation
@@ -121,7 +121,7 @@ type IPAddressOrder struct {
 // Return response for updateIPAddress mutation
 type IPAddressUpdatePayload struct {
 	// Updated ip block type
-	IPAddress IPAddress `json:"ip_address"`
+	IPAddress IPAddress `json:"ipAddress"`
 }
 
 // IPAddressWhereInput is used for filtering IPAddress objects.
@@ -179,11 +179,11 @@ type IPAddressWhereInput struct {
 	HasIPBlockWith []*IPBlockWhereInput `json:"hasIPBlockWith,omitempty"`
 }
 
-// IPAddressable provides an interface for describing IP addresses attached to a node
+// IPAddressable provides an interface for determining if a node can have IP addresses attached to it
 type IPAddressable struct {
 	ID gidx.PrefixedID `json:"id"`
-	// IPAddressable describes IP addresses attached to a node
-	IPAddresses []*IPAddress `json:"IPAddresses"`
+	// ipAddresses returns all the ip addresses attached to the node
+	IPAddresses []*IPAddress `json:"ipAddresses"`
 }
 
 func (IPAddressable) IsEntity() {}
@@ -223,7 +223,7 @@ type IPBlockConnection struct {
 // Return response for createIPBlock mutation
 type IPBlockCreatePayload struct {
 	// Created ip block type
-	IPBlock IPBlock `json:"ip_block"`
+	IPBlock IPBlock `json:"ipBlock"`
 }
 
 // Return response for deleteIPBlock mutation
@@ -280,7 +280,7 @@ type IPBlockTypeConnection struct {
 // Return response for createIPBlockType mutation
 type IPBlockTypeCreatePayload struct {
 	// Created ip block type
-	IPBlockType IPBlockType `json:"ip_block_type"`
+	IPBlockType IPBlockType `json:"ipBlockType"`
 }
 
 // Return response for deleteIPBlockType mutation
@@ -308,7 +308,7 @@ type IPBlockTypeOrder struct {
 // Return response for updateIPBlockType mutation
 type IPBlockTypeUpdatePayload struct {
 	// Updated ip block type
-	IPBlockType IPBlockType `json:"ip_block_type"`
+	IPBlockType IPBlockType `json:"ipBlockType"`
 }
 
 // IPBlockTypeWhereInput is used for filtering IPBlockType objects.
@@ -366,7 +366,7 @@ type IPBlockTypeWhereInput struct {
 // Return response for updateIPBlock mutation
 type IPBlockUpdatePayload struct {
 	// Updated ip block type
-	IPBlock IPBlock `json:"ip_block"`
+	IPBlock IPBlock `json:"ipBlock"`
 }
 
 // IPBlockWhereInput is used for filtering IPBlock objects.
@@ -445,7 +445,7 @@ type PageInfo struct {
 
 type ResourceOwner struct {
 	ID          gidx.PrefixedID       `json:"id"`
-	IPBlockType IPBlockTypeConnection `json:"ip_block_type"`
+	IPBlockType IPBlockTypeConnection `json:"ipBlockType"`
 }
 
 func (ResourceOwner) IsEntity() {}

--- a/internal/testclient/ipaddress.gql
+++ b/internal/testclient/ipaddress.gql
@@ -1,5 +1,5 @@
 query getIPAddress($id: ID!) {
-  ip_address(id: $id) {
+  ipAddress(id: $id) {
     id
     ip
     reserved
@@ -14,7 +14,7 @@ query getIPAddress($id: ID!) {
 
 mutation CreateIPAddress($input: CreateIPAddressInput!) {
   createIPAddress(input: $input) {
-    ip_address {
+    ipAddress {
       id
       ip
       reserved
@@ -35,7 +35,7 @@ mutation CreateIPAddress($input: CreateIPAddressInput!) {
 
 mutation UpdateIPAddress($id: ID!, $input: UpdateIPAddressInput!) {
   updateIPAddress(id: $id, input: $input) {
-    ip_address {
+    ipAddress {
       id
       ip
       reserved

--- a/internal/testclient/ipaddressable.gql
+++ b/internal/testclient/ipaddressable.gql
@@ -1,9 +1,9 @@
 query GetIPAddressesByNode($id: ID!) {
-  _entities(representations: { __typename: "IPAddressable", id: $id}) {
+  _entities(representations: { __typename: "IPAddressable", id: $id }) {
     ... on IPAddressable {
-        IPAddresses {
-          ip 
-          }
-        }
+      ipAddresses {
+        ip
       }
     }
+  }
+}

--- a/internal/testclient/ipblock.gql
+++ b/internal/testclient/ipblock.gql
@@ -1,73 +1,72 @@
 query GetIPBlock($id: ID!) {
-  ip_block(id: $id) {
+  ipBlock(id: $id) {
     id
     prefix
     allowAutoSubnet
     allowAutoAllocate
     ipBlockType {
-        id
+      id
     }
     ipAddress {
-        edges {
-            node {
-                id
-                ip
-                reserved
-            }
+      edges {
+        node {
+          id
+          ip
+          reserved
         }
+      }
     }
   }
 }
 
 mutation IPBlockCreate($input: CreateIPBlockInput!) {
-    createIPBlock(input: $input) {
-        ip_block {
+  createIPBlock(input: $input) {
+    ipBlock {
+      id
+      prefix
+      allowAutoSubnet
+      allowAutoAllocate
+      ipBlockType {
+        id
+      }
+      ipAddress {
+        edges {
+          node {
             id
-            prefix
-            allowAutoSubnet
-            allowAutoAllocate
-            ipBlockType {
-                id
-            }
-            ipAddress {
-                edges {
-                    node {
-                        id
-                        ip
-                        reserved
-                    }
-                }
-            }
+            ip
+            reserved
+          }
         }
+      }
     }
-
+  }
 }
 
 mutation IPBlockUpdate($id: ID!, $input: UpdateIPBlockInput!) {
-    updateIPBlock(id: $id, input: $input) {
-        ip_block {
+  updateIPBlock(id: $id, input: $input) {
+    ipBlock {
+      id
+      prefix
+      allowAutoSubnet
+      allowAutoAllocate
+      ipBlockType {
+        id
+      }
+      ipAddress {
+        edges {
+          node {
             id
-            prefix
-            allowAutoSubnet
-            allowAutoAllocate
-            ipBlockType {
-                id
-            }
-            ipAddress {
-                edges {
-                    node {
-                        id
-                        ip
-                        reserved
-                    }
-                }
-            }
+            ip
+            reserved
+          }
         }
+      }
     }
+  }
 }
 
 mutation IPBlockDelete($id: ID!) {
-    deleteIPBlock(id: $id) {
-        deletedID
-    }
+  deleteIPBlock(id: $id) {
+    deletedID
+  }
 }

--- a/internal/testclient/ipblocktype.gql
+++ b/internal/testclient/ipblocktype.gql
@@ -1,57 +1,57 @@
 query GetIPBlockType($id: ID!) {
-    ip_block_type(id: $id) {
-        id
-        name
-        owner{
-            id
-        }
-        createdAt
-        updatedAt
+  ipBlockType(id: $id) {
+    id
+    name
+    owner {
+      id
     }
+    createdAt
+    updatedAt
+  }
 }
 
-query ListIPBlockTypes($id:ID!, $orderBy: IPBlockTypeOrder){
-    _entities(representations: [{__typename: "ResourceOwner", id: $id}]) {
-        ... on ResourceOwner {
-            ip_block_type(orderBy: $orderBy) {
-                edges {
-                    node {
-                        id
-                        name
-                    }
-                }
-            }
+query ListIPBlockTypes($id: ID!, $orderBy: IPBlockTypeOrder) {
+  _entities(representations: [{ __typename: "ResourceOwner", id: $id }]) {
+    ... on ResourceOwner {
+      ipBlockType(orderBy: $orderBy) {
+        edges {
+          node {
+            id
+            name
+          }
         }
+      }
     }
+  }
 }
 
 mutation IPBlockTypeCreate($input: CreateIPBlockTypeInput!) {
-    createIPBlockType(input: $input) {
-        ip_block_type {
-            id
-            name
-            owner{
-                id
-            }
-            createdAt
-            updatedAt
-        }
+  createIPBlockType(input: $input) {
+    ipBlockType {
+      id
+      name
+      owner {
+        id
+      }
+      createdAt
+      updatedAt
     }
+  }
 }
 
-mutation IPBlockTypeUpdate($id: ID!,$input: UpdateIPBlockTypeInput!) {
-    updateIPBlockType(id: $id input: $input) {
-        ip_block_type {
-            id
-            name
-            createdAt
-            updatedAt
-        }
+mutation IPBlockTypeUpdate($id: ID!, $input: UpdateIPBlockTypeInput!) {
+  updateIPBlockType(id: $id, input: $input) {
+    ipBlockType {
+      id
+      name
+      createdAt
+      updatedAt
     }
+  }
 }
 
-mutation IPBlockTypeDelete($id: ID!){
-    deleteIPBlockType(id: $id){
-        deletedID
-    }
+mutation IPBlockTypeDelete($id: ID!) {
+  deleteIPBlockType(id: $id) {
+    deletedID
+  }
 }

--- a/internal/testclient/schema/schema.graphql
+++ b/internal/testclient/schema/schema.graphql
@@ -60,7 +60,7 @@ type IPAddress implements Node @key(fields: "id") @prefixedID(prefix: "ipamipa")
 	"""Reserve the IP without it being assigned."""
 	reserved: Boolean!
 	ipBlock: IPBlock!
-	"""IPAddresses that are associated with a given node"""
+	"""node the ip address is attached to"""
 	node: IPAddressable!
 }
 """A connection to a list of items."""
@@ -75,7 +75,7 @@ type IPAddressConnection {
 """Return response for createIPAddress mutation"""
 type IPAddressCreatePayload {
 	"""Created ip block type"""
-	ip_address: IPAddress!
+	ipAddress: IPAddress!
 }
 """Return response for deleteIPAddress mutation"""
 type IPAddressDeletePayload {
@@ -110,7 +110,7 @@ enum IPAddressOrderField {
 """Return response for updateIPAddress mutation"""
 type IPAddressUpdatePayload {
 	"""Updated ip block type"""
-	ip_address: IPAddress!
+	ipAddress: IPAddress!
 }
 """
 IPAddressWhereInput is used for filtering IPAddress objects.
@@ -168,11 +168,11 @@ input IPAddressWhereInput {
 	hasIPBlock: Boolean
 	hasIPBlockWith: [IPBlockWhereInput!]
 }
-"""IPAddressable provides an interface for describing IP addresses attached to a node"""
+"""IPAddressable provides an interface for determining if a node can have IP addresses attached to it"""
 type IPAddressable @key(fields: "id") @interfaceObject {
 	id: ID!
-	"""IPAddressable describes IP addresses attached to a node"""
-	IPAddresses: [IPAddress]!
+	"""ipAddresses returns all the ip addresses attached to the node"""
+	ipAddresses: [IPAddress]!
 }
 type IPBlock implements Node @key(fields: "id") @prefixedID(prefix: "ipamibk") {
 	"""The ID of the IP Block."""
@@ -218,7 +218,7 @@ type IPBlockConnection {
 """Return response for createIPBlock mutation"""
 type IPBlockCreatePayload {
 	"""Created ip block type"""
-	ip_block: IPBlock!
+	ipBlock: IPBlock!
 }
 """Return response for deleteIPBlock mutation"""
 type IPBlockDeletePayload {
@@ -292,7 +292,7 @@ type IPBlockTypeConnection {
 """Return response for createIPBlockType mutation"""
 type IPBlockTypeCreatePayload {
 	"""Created ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """Return response for deleteIPBlockType mutation"""
 type IPBlockTypeDeletePayload {
@@ -324,7 +324,7 @@ enum IPBlockTypeOrderField {
 """Return response for updateIPBlockType mutation"""
 type IPBlockTypeUpdatePayload {
 	"""Updated ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """
 IPBlockTypeWhereInput is used for filtering IPBlockType objects.
@@ -382,7 +382,7 @@ input IPBlockTypeWhereInput {
 """Return response for updateIPBlock mutation"""
 type IPBlockUpdatePayload {
 	"""Updated ip block type"""
-	ip_block: IPBlock!
+	ipBlock: IPBlock!
 }
 """
 IPBlockWhereInput is used for filtering IPBlock objects.
@@ -449,22 +449,16 @@ input IPBlockWhereInput {
 """A valid JSON string."""
 scalar JSON
 type Mutation {
-	"""Create a new ip block type"""
-	createIPAddress(
-		"""Name of the ip block type"""
-		input: CreateIPAddressInput!
-	): IPAddressCreatePayload!
+	"""Create a new ip address"""
+	createIPAddress(input: CreateIPAddressInput!): IPAddressCreatePayload!
 	"""Update an existing ip block type"""
 	updateIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address to update"""
 		id: ID!
-
-		"""Name of the ip block type"""
-		input: UpdateIPAddressInput!
-	): IPAddressUpdatePayload!
+	input: UpdateIPAddressInput!): IPAddressUpdatePayload!
 	"""Delete an existing ip block type"""
 	deleteIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address"""
 		id: ID!
 	): IPAddressDeletePayload!
 	"""Create a new ip block type"""
@@ -476,10 +470,7 @@ type Mutation {
 	updateIPBlock(
 		"""ID of the ip block type"""
 		id: ID!
-
-		"""Name of the ip block type"""
-		input: UpdateIPBlockInput!
-	): IPBlockUpdatePayload!
+	input: UpdateIPBlockInput!): IPBlockUpdatePayload!
 	"""Delete an existing ip block type"""
 	deleteIPBlock(
 		"""ID of the ip block type"""
@@ -535,17 +526,17 @@ type PageInfo @shareable {
 }
 type Query {
 	"""Look up ip block type by ID"""
-	ip_address(
+	ipAddress(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPAddress!
 	"""Look up ip block type by ID"""
-	ip_block(
+	ipBlock(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPBlock!
 	"""Look up ip block type by ID"""
-	ip_block_type(
+	ipBlockType(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPBlockType!
@@ -554,7 +545,7 @@ type Query {
 }
 type ResourceOwner @key(fields: "id") @interfaceObject {
 	id: ID!
-	ip_block_type(
+	ipBlockType(
 		"""Returns the elements in the list that come after the specified cursor."""
 		after: Cursor
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -47,7 +47,7 @@ type IPAddress implements Node @key(fields: "id") @prefixedID(prefix: "ipamipa")
 	"""Reserve the IP without it being assigned."""
 	reserved: Boolean!
 	ipBlock: IPBlock!
-	"""IPAddresses that are associated with a given node"""
+	"""node the ip address is attached to"""
 	node: IPAddressable!
 }
 """A connection to a list of items."""
@@ -62,7 +62,7 @@ type IPAddressConnection {
 """Return response for createIPAddress mutation"""
 type IPAddressCreatePayload {
 	"""Created ip block type"""
-	ip_address: IPAddress!
+	ipAddress: IPAddress!
 }
 """Return response for deleteIPAddress mutation"""
 type IPAddressDeletePayload {
@@ -97,7 +97,7 @@ enum IPAddressOrderField {
 """Return response for updateIPAddress mutation"""
 type IPAddressUpdatePayload {
 	"""Updated ip block type"""
-	ip_address: IPAddress!
+	ipAddress: IPAddress!
 }
 """
 IPAddressWhereInput is used for filtering IPAddress objects.
@@ -155,11 +155,11 @@ input IPAddressWhereInput {
 	hasIPBlock: Boolean
 	hasIPBlockWith: [IPBlockWhereInput!]
 }
-"""IPAddressable provides an interface for describing IP addresses attached to a node"""
+"""IPAddressable provides an interface for determining if a node can have IP addresses attached to it"""
 type IPAddressable @key(fields: "id") @interfaceObject {
 	id: ID!
-	"""IPAddressable describes IP addresses attached to a node"""
-	IPAddresses: [IPAddress]!
+	"""ipAddresses returns all the ip addresses attached to the node"""
+	ipAddresses: [IPAddress]!
 }
 type IPBlock implements Node @key(fields: "id") @prefixedID(prefix: "ipamibk") {
 	"""The ID of the IP Block."""
@@ -205,7 +205,7 @@ type IPBlockConnection {
 """Return response for createIPBlock mutation"""
 type IPBlockCreatePayload {
 	"""Created ip block type"""
-	ip_block: IPBlock!
+	ipBlock: IPBlock!
 }
 """Return response for deleteIPBlock mutation"""
 type IPBlockDeletePayload {
@@ -279,7 +279,7 @@ type IPBlockTypeConnection {
 """Return response for createIPBlockType mutation"""
 type IPBlockTypeCreatePayload {
 	"""Created ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """Return response for deleteIPBlockType mutation"""
 type IPBlockTypeDeletePayload {
@@ -311,7 +311,7 @@ enum IPBlockTypeOrderField {
 """Return response for updateIPBlockType mutation"""
 type IPBlockTypeUpdatePayload {
 	"""Updated ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """
 IPBlockTypeWhereInput is used for filtering IPBlockType objects.
@@ -369,7 +369,7 @@ input IPBlockTypeWhereInput {
 """Return response for updateIPBlock mutation"""
 type IPBlockUpdatePayload {
 	"""Updated ip block type"""
-	ip_block: IPBlock!
+	ipBlock: IPBlock!
 }
 """
 IPBlockWhereInput is used for filtering IPBlock objects.
@@ -436,22 +436,16 @@ input IPBlockWhereInput {
 """A valid JSON string."""
 scalar JSON
 type Mutation {
-	"""Create a new ip block type"""
-	createIPAddress(
-		"""Name of the ip block type"""
-		input: CreateIPAddressInput!
-	): IPAddressCreatePayload!
+	"""Create a new ip address"""
+	createIPAddress(input: CreateIPAddressInput!): IPAddressCreatePayload!
 	"""Update an existing ip block type"""
 	updateIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address to update"""
 		id: ID!
-
-		"""Name of the ip block type"""
-		input: UpdateIPAddressInput!
-	): IPAddressUpdatePayload!
+	input: UpdateIPAddressInput!): IPAddressUpdatePayload!
 	"""Delete an existing ip block type"""
 	deleteIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address"""
 		id: ID!
 	): IPAddressDeletePayload!
 	"""Create a new ip block type"""
@@ -463,10 +457,7 @@ type Mutation {
 	updateIPBlock(
 		"""ID of the ip block type"""
 		id: ID!
-
-		"""Name of the ip block type"""
-		input: UpdateIPBlockInput!
-	): IPBlockUpdatePayload!
+	input: UpdateIPBlockInput!): IPBlockUpdatePayload!
 	"""Delete an existing ip block type"""
 	deleteIPBlock(
 		"""ID of the ip block type"""
@@ -522,17 +513,17 @@ type PageInfo @shareable {
 }
 type Query {
 	"""Look up ip block type by ID"""
-	ip_address(
+	ipAddress(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPAddress!
 	"""Look up ip block type by ID"""
-	ip_block(
+	ipBlock(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPBlock!
 	"""Look up ip block type by ID"""
-	ip_block_type(
+	ipBlockType(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPBlockType!
@@ -541,7 +532,7 @@ type Query {
 }
 type ResourceOwner @key(fields: "id") @interfaceObject {
 	id: ID!
-	ip_block_type(
+	ipBlockType(
 		"""Returns the elements in the list that come after the specified cursor."""
 		after: Cursor
 

--- a/schema/ipaddress.graphql
+++ b/schema/ipaddress.graphql
@@ -1,77 +1,69 @@
 extend type Query {
+  """
+  Look up ip block type by ID
+  """
+  ipAddress(
     """
-    Look up ip block type by ID
+    ID of the ip block type
     """
-    ip_address(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPAddress!
+    id: ID!
+  ): IPAddress!
 }
 
-extend type Mutation{
+extend type Mutation {
+  """
+  Create a new ip address
+  """
+  createIPAddress(input: CreateIPAddressInput!): IPAddressCreatePayload!
+  """
+  Update an existing ip block type
+  """
+  updateIPAddress(
     """
-    Create a new ip block type
+    ID of the ip address to update
     """
-    createIPAddress(
-        """
-        Name of the ip block type
-        """
-        input: CreateIPAddressInput!
-    ): IPAddressCreatePayload!
+    id: ID!
+    input: UpdateIPAddressInput!
+  ): IPAddressUpdatePayload!
+  """
+  Delete an existing ip block type
+  """
+  deleteIPAddress(
     """
-    Update an existing ip block type
+    ID of the ip address
     """
-    updateIPAddress(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-        """
-        Name of the ip block type
-        """
-        input: UpdateIPAddressInput!
-    ): IPAddressUpdatePayload!
-    """
-    Delete an existing ip block type
-    """
-    deleteIPAddress(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPAddressDeletePayload!
+    id: ID!
+  ): IPAddressDeletePayload!
 }
 
 """
 Return response for createIPAddress mutation
 """
 type IPAddressCreatePayload {
-    """
-    Created ip block type
-    """
-    ip_address: IPAddress!
+  """
+  Created ip block type
+  """
+  ipAddress: IPAddress!
 }
 
 """
 Return response for updateIPAddress mutation
 """
 type IPAddressUpdatePayload {
-    """
-    Updated ip block type
-    """
-    ip_address: IPAddress!
+  """
+  Updated ip block type
+  """
+  ipAddress: IPAddress!
 }
 
 """
 Return response for deleteIPAddress mutation
 """
 type IPAddressDeletePayload {
-    """
-    Deleted ip block type
-    """
-    deletedID: ID!
+  """
+  Deleted ip block type
+  """
+  deletedID: ID!
 }
 
 extend schema
@@ -81,19 +73,19 @@ extend schema
   )
 
 """
-IPAddressable provides an interface for describing IP addresses attached to a node
+IPAddressable provides an interface for determining if a node can have IP addresses attached to it
 """
 type IPAddressable @key(fields: "id") @interfaceObject {
   id: ID!
   """
-  IPAddressable describes IP addresses attached to a node
+  ipAddresses returns all the ip addresses attached to the node
   """
-  IPAddresses: [IPAddress]! @goField(forceResolver: true)
+  ipAddresses: [IPAddress]! @goField(forceResolver: true)
 }
 
 extend type IPAddress {
   """
-  IPAddresses that are associated with a given node
+  node the ip address is attached to
   """
   node: IPAddressable!
 }

--- a/schema/ipblock.graphql
+++ b/schema/ipblock.graphql
@@ -1,75 +1,72 @@
 extend type Query {
+  """
+  Look up ip block type by ID
+  """
+  ipBlock(
     """
-    Look up ip block type by ID
+    ID of the ip block type
     """
-    ip_block(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlock!
+    id: ID!
+  ): IPBlock!
 }
 
-extend type Mutation{
+extend type Mutation {
+  """
+  Create a new ip block type
+  """
+  createIPBlock(
     """
-    Create a new ip block type
+    Name of the ip block type
     """
-    createIPBlock(
-        """
-        Name of the ip block type
-        """
-        input: CreateIPBlockInput!
-    ): IPBlockCreatePayload!
+    input: CreateIPBlockInput!
+  ): IPBlockCreatePayload!
+  """
+  Update an existing ip block type
+  """
+  updateIPBlock(
     """
-    Update an existing ip block type
+    ID of the ip block type
     """
-    updateIPBlock(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-        """
-        Name of the ip block type
-        """
-        input: UpdateIPBlockInput!
-    ): IPBlockUpdatePayload!
+    id: ID!
+    input: UpdateIPBlockInput!
+  ): IPBlockUpdatePayload!
+  """
+  Delete an existing ip block type
+  """
+  deleteIPBlock(
     """
-    Delete an existing ip block type
+    ID of the ip block type
     """
-    deleteIPBlock(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlockDeletePayload!
+    id: ID!
+  ): IPBlockDeletePayload!
 }
 
 """
 Return response for createIPBlock mutation
 """
 type IPBlockCreatePayload {
-    """
-    Created ip block type
-    """
-    ip_block: IPBlock!
+  """
+  Created ip block type
+  """
+  ipBlock: IPBlock!
 }
 
 """
 Return response for updateIPBlock mutation
 """
 type IPBlockUpdatePayload {
-    """
-    Updated ip block type
-    """
-    ip_block: IPBlock!
+  """
+  Updated ip block type
+  """
+  ipBlock: IPBlock!
 }
 
 """
 Return response for deleteIPBlock mutation
 """
 type IPBlockDeletePayload {
-    """
-    Deleted ip block type
-    """
-    deletedID: ID!
+  """
+  Deleted ip block type
+  """
+  deletedID: ID!
 }

--- a/schema/ipblocktype.graphql
+++ b/schema/ipblocktype.graphql
@@ -1,75 +1,75 @@
 extend type Query {
+  """
+  Look up ip block type by ID
+  """
+  ipBlockType(
     """
-    Look up ip block type by ID
+    ID of the ip block type
     """
-    ip_block_type(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlockType!
+    id: ID!
+  ): IPBlockType!
 }
 
-extend type Mutation{
+extend type Mutation {
+  """
+  Create a new ip block type
+  """
+  createIPBlockType(
     """
-    Create a new ip block type
+    Name of the ip block type
     """
-    createIPBlockType(
-        """
-        Name of the ip block type
-        """
-        input: CreateIPBlockTypeInput!
-    ): IPBlockTypeCreatePayload!
+    input: CreateIPBlockTypeInput!
+  ): IPBlockTypeCreatePayload!
+  """
+  Update an existing ip block type
+  """
+  updateIPBlockType(
     """
-    Update an existing ip block type
+    ID of the ip block type
     """
-    updateIPBlockType(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-        """
-        Name of the ip block type
-        """
-        input: UpdateIPBlockTypeInput!
-    ): IPBlockTypeUpdatePayload!
+    id: ID!
     """
-    Delete an existing ip block type
+    Name of the ip block type
     """
-    deleteIPBlockType(
-        """
-        ID of the ip block type
-        """
-        id: ID!
-    ): IPBlockTypeDeletePayload!
+    input: UpdateIPBlockTypeInput!
+  ): IPBlockTypeUpdatePayload!
+  """
+  Delete an existing ip block type
+  """
+  deleteIPBlockType(
+    """
+    ID of the ip block type
+    """
+    id: ID!
+  ): IPBlockTypeDeletePayload!
 }
 
 """
 Return response for createIPBlockType mutation
 """
 type IPBlockTypeCreatePayload {
-    """
-    Created ip block type
-    """
-    ip_block_type: IPBlockType!
+  """
+  Created ip block type
+  """
+  ipBlockType: IPBlockType!
 }
 
 """
 Return response for updateIPBlockType mutation
 """
 type IPBlockTypeUpdatePayload {
-    """
-    Updated ip block type
-    """
-    ip_block_type: IPBlockType!
+  """
+  Updated ip block type
+  """
+  ipBlockType: IPBlockType!
 }
 
 """
 Return response for deleteIPBlockType mutation
 """
 type IPBlockTypeDeletePayload {
-    """
-    Deleted ip block type
-    """
-    deletedID: ID!
+  """
+  Deleted ip block type
+  """
+  deletedID: ID!
 }

--- a/schema/owner.graphql
+++ b/schema/owner.graphql
@@ -2,7 +2,7 @@ directive @prefixedID(prefix: String!) on OBJECT
 
 type ResourceOwner @key(fields: "id") @interfaceObject {
   id: ID!
-  ip_block_type(
+  ipBlockType(
     """
     Returns the elements in the list that come after the specified cursor.
     """


### PR DESCRIPTION
Best practices for graphql recommend using camelCase not snake_case. More details on these can be seen here: https://www.apollographql.com/docs/technotes/TN0002-schema-naming-conventions/