### PR TITLE
BREAKING: Clean up graphql names to match standard naming practices.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -105,7 +105,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
-github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
@@ -412,8 +411,6 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
@@ -466,8 +463,6 @@ github.com/testcontainers/testcontainers-go v0.21.0 h1:syePAxdeTzfkap+RrJaQZpJQ/
 github.com/testcontainers/testcontainers-go v0.21.0/go.mod h1:c1ez3WVRHq7T/Aj+X3TIipFBwkBaNT5iNCY8+1b83Ng=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.21.0 h1:rFPyTR7pPMiHcDktXwd5iZ+mA1cHH/WRa+knxBcY8wU=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.21.0/go.mod h1:Uoia8PX1RewxkJTbeXGBK6vgMjlmRbnL/4n0EXH2Z54=
-github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
-github.com/urfave/cli/v2 v2.25.5 h1:d0NIAyhh5shGscroL7ek/Ya9QYQE0KNabJgiUinIQkc=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
@@ -483,7 +478,6 @@ github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vb
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wundergraph/graphql-go-tools v1.63.2 h1:ussoKVVy6r/sgvsGJRevlVuQSyETQQ/w0F77+OB408U=
 github.com/wundergraph/graphql-go-tools v1.63.2/go.mod h1:44QXSTiT0Jn82792Qjr7wHEJruC+RnofVJb5hM8Gins=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/graphapi/gen_models.go
+++ b/internal/graphapi/gen_models.go
@@ -9,20 +9,20 @@ import (
 
 // Return response for createIPAddress mutation
 type IPAddressCreatePayload struct {
-	// Created ip block type
-	IPAddress *generated.IPAddress `json:"ip_address"`
+	// Created ip address
+	IPAddress *generated.IPAddress `json:"ipAddress"`
 }
 
 // Return response for deleteIPAddress mutation
 type IPAddressDeletePayload struct {
-	// Deleted ip block type
+	// Deleted ip address ID
 	DeletedID gidx.PrefixedID `json:"deletedID"`
 }
 
 // Return response for updateIPAddress mutation
 type IPAddressUpdatePayload struct {
-	// Updated ip block type
-	IPAddress *generated.IPAddress `json:"ip_address"`
+	// Updated ip address
+	IPAddress *generated.IPAddress `json:"ipAddress"`
 }
 
 // IPAddressable provides an interface for describing IP addresses attached to a node
@@ -36,20 +36,20 @@ func (IPAddressable) IsEntity() {}
 
 // Return response for createIPBlock mutation
 type IPBlockCreatePayload struct {
-	// Created ip block type
-	IPBlock *generated.IPBlock `json:"ip_block"`
+	// Created ip block
+	IPBlock *generated.IPBlock `json:"ipBlock"`
 }
 
 // Return response for deleteIPBlock mutation
 type IPBlockDeletePayload struct {
-	// Deleted ip block type
+	// Deleted ip block
 	DeletedID gidx.PrefixedID `json:"deletedID"`
 }
 
 // Return response for createIPBlockType mutation
 type IPBlockTypeCreatePayload struct {
 	// Created ip block type
-	IPBlockType *generated.IPBlockType `json:"ip_block_type"`
+	IPBlockType *generated.IPBlockType `json:"ipBlockType"`
 }
 
 // Return response for deleteIPBlockType mutation
@@ -61,18 +61,18 @@ type IPBlockTypeDeletePayload struct {
 // Return response for updateIPBlockType mutation
 type IPBlockTypeUpdatePayload struct {
 	// Updated ip block type
-	IPBlockType *generated.IPBlockType `json:"ip_block_type"`
+	IPBlockType *generated.IPBlockType `json:"ipBlockType"`
 }
 
 // Return response for updateIPBlock mutation
 type IPBlockUpdatePayload struct {
-	// Updated ip block type
-	IPBlock *generated.IPBlock `json:"ip_block"`
+	// Updated ip block
+	IPBlock *generated.IPBlock `json:"ipBlock"`
 }
 
 type ResourceOwner struct {
 	ID          gidx.PrefixedID                  `json:"id"`
-	IPBlockType *generated.IPBlockTypeConnection `json:"ip_block_type"`
+	IPBlockType *generated.IPBlockTypeConnection `json:"ipBlockType"`
 }
 
 func (ResourceOwner) IsEntity() {}

--- a/internal/graphapi/generated.go
+++ b/internal/graphapi/generated.go
@@ -384,7 +384,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPAddressConnection.TotalCount(childComplexity), true
 
-	case "IPAddressCreatePayload.ip_address":
+	case "IPAddressCreatePayload.ipAddress":
 		if e.complexity.IPAddressCreatePayload.IPAddress == nil {
 			break
 		}
@@ -412,7 +412,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPAddressEdge.Node(childComplexity), true
 
-	case "IPAddressUpdatePayload.ip_address":
+	case "IPAddressUpdatePayload.ipAddress":
 		if e.complexity.IPAddressUpdatePayload.IPAddress == nil {
 			break
 		}
@@ -515,7 +515,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPBlockConnection.TotalCount(childComplexity), true
 
-	case "IPBlockCreatePayload.ip_block":
+	case "IPBlockCreatePayload.ipBlock":
 		if e.complexity.IPBlockCreatePayload.IPBlock == nil {
 			break
 		}
@@ -611,7 +611,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPBlockTypeConnection.TotalCount(childComplexity), true
 
-	case "IPBlockTypeCreatePayload.ip_block_type":
+	case "IPBlockTypeCreatePayload.ipBlockType":
 		if e.complexity.IPBlockTypeCreatePayload.IPBlockType == nil {
 			break
 		}
@@ -639,14 +639,14 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IPBlockTypeEdge.Node(childComplexity), true
 
-	case "IPBlockTypeUpdatePayload.ip_block_type":
+	case "IPBlockTypeUpdatePayload.ipBlockType":
 		if e.complexity.IPBlockTypeUpdatePayload.IPBlockType == nil {
 			break
 		}
 
 		return e.complexity.IPBlockTypeUpdatePayload.IPBlockType(childComplexity), true
 
-	case "IPBlockUpdatePayload.ip_block":
+	case "IPBlockUpdatePayload.ipBlock":
 		if e.complexity.IPBlockUpdatePayload.IPBlock == nil {
 			break
 		}
@@ -789,36 +789,36 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PageInfo.StartCursor(childComplexity), true
 
-	case "Query.ip_address":
+	case "Query.ipAddress":
 		if e.complexity.Query.IPAddress == nil {
 			break
 		}
 
-		args, err := ec.field_Query_ip_address_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_ipAddress_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
 		return e.complexity.Query.IPAddress(childComplexity, args["id"].(gidx.PrefixedID)), true
 
-	case "Query.ip_block":
+	case "Query.ipBlock":
 		if e.complexity.Query.IPBlock == nil {
 			break
 		}
 
-		args, err := ec.field_Query_ip_block_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_ipBlock_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
 		return e.complexity.Query.IPBlock(childComplexity, args["id"].(gidx.PrefixedID)), true
 
-	case "Query.ip_block_type":
+	case "Query.ipBlockType":
 		if e.complexity.Query.IPBlockType == nil {
 			break
 		}
 
-		args, err := ec.field_Query_ip_block_type_args(context.TODO(), rawArgs)
+		args, err := ec.field_Query_ipBlockType_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
@@ -851,12 +851,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ResourceOwner.ID(childComplexity), true
 
-	case "ResourceOwner.ip_block_type":
+	case "ResourceOwner.ipBlockType":
 		if e.complexity.ResourceOwner.IPBlockType == nil {
 			break
 		}
 
-		args, err := ec.field_ResourceOwner_ip_block_type_args(context.TODO(), rawArgs)
+		args, err := ec.field_ResourceOwner_ipBlockType_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
@@ -1426,11 +1426,11 @@ input UpdateIPBlockTypeInput {
 `, BuiltIn: false},
 	{Name: "../../schema/ipaddress.graphql", Input: `extend type Query {
     """
-    Look up ip block type by ID
+    Look up ip address by ID
     """
-    ip_address(
+    ipAddress(
         """
-        ID of the ip block type
+        ID of the ip address
         """
         id: ID!
     ): IPAddress!
@@ -1438,33 +1438,33 @@ input UpdateIPBlockTypeInput {
 
 extend type Mutation{
     """
-    Create a new ip block type
+    Create a new ip address
     """
     createIPAddress(
         """
-        Name of the ip block type
+        values of the ip address
         """
         input: CreateIPAddressInput!
     ): IPAddressCreatePayload!
     """
-    Update an existing ip block type
+    Update an existing ip address
     """
     updateIPAddress(
         """
-        ID of the ip block type
+        ID of the ip address
         """
         id: ID!
         """
-        Name of the ip block type
+        New values for the ip address
         """
         input: UpdateIPAddressInput!
     ): IPAddressUpdatePayload!
     """
-    Delete an existing ip block type
+    Delete an existing ip address
     """
     deleteIPAddress(
         """
-        ID of the ip block type
+        ID of the ip address
         """
         id: ID!
     ): IPAddressDeletePayload!
@@ -1475,9 +1475,9 @@ Return response for createIPAddress mutation
 """
 type IPAddressCreatePayload {
     """
-    Created ip block type
+    Created ip address
     """
-    ip_address: IPAddress!
+    ipAddress: IPAddress!
 }
 
 """
@@ -1485,9 +1485,9 @@ Return response for updateIPAddress mutation
 """
 type IPAddressUpdatePayload {
     """
-    Updated ip block type
+    Updated ip address
     """
-    ip_address: IPAddress!
+    ipAddress: IPAddress!
 }
 
 """
@@ -1495,7 +1495,7 @@ Return response for deleteIPAddress mutation
 """
 type IPAddressDeletePayload {
     """
-    Deleted ip block type
+    Deleted ip address ID
     """
     deletedID: ID!
 }
@@ -1522,14 +1522,15 @@ extend type IPAddress {
   IPAddresses that are associated with a given node
   """
   node: IPAddressable!
-}`, BuiltIn: false},
+}
+`, BuiltIn: false},
 	{Name: "../../schema/ipblock.graphql", Input: `extend type Query {
     """
-    Look up ip block type by ID
+    Look up ip block by ID
     """
-    ip_block(
+    ipBlock(
         """
-        ID of the ip block type
+        ID of the ip block
         """
         id: ID!
     ): IPBlock!
@@ -1537,33 +1538,33 @@ extend type IPAddress {
 
 extend type Mutation{
     """
-    Create a new ip block type
+    Create a new ip block
     """
     createIPBlock(
         """
-        Name of the ip block type
+        Name of the ip block
         """
         input: CreateIPBlockInput!
     ): IPBlockCreatePayload!
     """
-    Update an existing ip block type
+    Update an existing ip block
     """
     updateIPBlock(
         """
-        ID of the ip block type
+        ID of the ip block
         """
         id: ID!
         """
-        Name of the ip block type
+        Name of the ip block
         """
         input: UpdateIPBlockInput!
     ): IPBlockUpdatePayload!
     """
-    Delete an existing ip block type
+    Delete an existing ip block
     """
     deleteIPBlock(
         """
-        ID of the ip block type
+        ID of the ip block
         """
         id: ID!
     ): IPBlockDeletePayload!
@@ -1574,9 +1575,9 @@ Return response for createIPBlock mutation
 """
 type IPBlockCreatePayload {
     """
-    Created ip block type
+    Created ip block
     """
-    ip_block: IPBlock!
+    ipBlock: IPBlock!
 }
 
 """
@@ -1584,9 +1585,9 @@ Return response for updateIPBlock mutation
 """
 type IPBlockUpdatePayload {
     """
-    Updated ip block type
+    Updated ip block
     """
-    ip_block: IPBlock!
+    ipBlock: IPBlock!
 }
 
 """
@@ -1594,7 +1595,7 @@ Return response for deleteIPBlock mutation
 """
 type IPBlockDeletePayload {
     """
-    Deleted ip block type
+    Deleted ip block
     """
     deletedID: ID!
 }
@@ -1603,7 +1604,7 @@ type IPBlockDeletePayload {
     """
     Look up ip block type by ID
     """
-    ip_block_type(
+    ipBlockType(
         """
         ID of the ip block type
         """
@@ -1652,7 +1653,7 @@ type IPBlockTypeCreatePayload {
     """
     Created ip block type
     """
-    ip_block_type: IPBlockType!
+    ipBlockType: IPBlockType!
 }
 
 """
@@ -1662,7 +1663,7 @@ type IPBlockTypeUpdatePayload {
     """
     Updated ip block type
     """
-    ip_block_type: IPBlockType!
+    ipBlockType: IPBlockType!
 }
 
 """
@@ -1679,7 +1680,7 @@ type IPBlockTypeDeletePayload {
 
 type ResourceOwner @key(fields: "id") @interfaceObject {
   id: ID!
-  ip_block_type(
+  ipBlockType(
     """
     Returns the elements in the list that come after the specified cursor.
     """
@@ -2187,7 +2188,7 @@ func (ec *executionContext) field_Query__entities_args(ctx context.Context, rawA
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_ip_address_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_ipAddress_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 gidx.PrefixedID
@@ -2202,7 +2203,7 @@ func (ec *executionContext) field_Query_ip_address_args(ctx context.Context, raw
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_ip_block_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_ipBlockType_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 gidx.PrefixedID
@@ -2217,7 +2218,7 @@ func (ec *executionContext) field_Query_ip_block_args(ctx context.Context, rawAr
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_ip_block_type_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Query_ipBlock_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 gidx.PrefixedID
@@ -2232,7 +2233,7 @@ func (ec *executionContext) field_Query_ip_block_type_args(ctx context.Context, 
 	return args, nil
 }
 
-func (ec *executionContext) field_ResourceOwner_ip_block_type_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_ResourceOwner_ipBlockType_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 *entgql.Cursor[gidx.PrefixedID]
@@ -2645,8 +2646,8 @@ func (ec *executionContext) fieldContext_Entity_findResourceOwnerByID(ctx contex
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ResourceOwner_id(ctx, field)
-			case "ip_block_type":
-				return ec.fieldContext_ResourceOwner_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_ResourceOwner_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ResourceOwner", field.Name)
 		},
@@ -3142,8 +3143,8 @@ func (ec *executionContext) fieldContext_IPAddressConnection_totalCount(ctx cont
 	return fc, nil
 }
 
-func (ec *executionContext) _IPAddressCreatePayload_ip_address(ctx context.Context, field graphql.CollectedField, obj *IPAddressCreatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPAddressCreatePayload_ip_address(ctx, field)
+func (ec *executionContext) _IPAddressCreatePayload_ipAddress(ctx context.Context, field graphql.CollectedField, obj *IPAddressCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPAddressCreatePayload_ipAddress(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3173,7 +3174,7 @@ func (ec *executionContext) _IPAddressCreatePayload_ip_address(ctx context.Conte
 	return ec.marshalNIPAddress2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPAddressCreatePayload_ip_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPAddressCreatePayload_ipAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPAddressCreatePayload",
 		Field:      field,
@@ -3347,8 +3348,8 @@ func (ec *executionContext) fieldContext_IPAddressEdge_cursor(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _IPAddressUpdatePayload_ip_address(ctx context.Context, field graphql.CollectedField, obj *IPAddressUpdatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPAddressUpdatePayload_ip_address(ctx, field)
+func (ec *executionContext) _IPAddressUpdatePayload_ipAddress(ctx context.Context, field graphql.CollectedField, obj *IPAddressUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPAddressUpdatePayload_ipAddress(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -3378,7 +3379,7 @@ func (ec *executionContext) _IPAddressUpdatePayload_ip_address(ctx context.Conte
 	return ec.marshalNIPAddress2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPAddressUpdatePayload_ip_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPAddressUpdatePayload_ipAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPAddressUpdatePayload",
 		Field:      field,
@@ -4041,8 +4042,8 @@ func (ec *executionContext) fieldContext_IPBlockConnection_totalCount(ctx contex
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockCreatePayload_ip_block(ctx context.Context, field graphql.CollectedField, obj *IPBlockCreatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockCreatePayload_ip_block(ctx, field)
+func (ec *executionContext) _IPBlockCreatePayload_ipBlock(ctx context.Context, field graphql.CollectedField, obj *IPBlockCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockCreatePayload_ipBlock(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4072,7 +4073,7 @@ func (ec *executionContext) _IPBlockCreatePayload_ip_block(ctx context.Context, 
 	return ec.marshalNIPBlock2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlock(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockCreatePayload_ip_block(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockCreatePayload_ipBlock(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockCreatePayload",
 		Field:      field,
@@ -4530,8 +4531,8 @@ func (ec *executionContext) fieldContext_IPBlockType_owner(ctx context.Context, 
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ResourceOwner_id(ctx, field)
-			case "ip_block_type":
-				return ec.fieldContext_ResourceOwner_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_ResourceOwner_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ResourceOwner", field.Name)
 		},
@@ -4684,8 +4685,8 @@ func (ec *executionContext) fieldContext_IPBlockTypeConnection_totalCount(ctx co
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockTypeCreatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeCreatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockTypeCreatePayload_ip_block_type(ctx, field)
+func (ec *executionContext) _IPBlockTypeCreatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockTypeCreatePayload_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4715,7 +4716,7 @@ func (ec *executionContext) _IPBlockTypeCreatePayload_ip_block_type(ctx context.
 	return ec.marshalNIPBlockType2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockTypeCreatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockTypeCreatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockTypeCreatePayload",
 		Field:      field,
@@ -4885,8 +4886,8 @@ func (ec *executionContext) fieldContext_IPBlockTypeEdge_cursor(ctx context.Cont
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockTypeUpdatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeUpdatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockTypeUpdatePayload_ip_block_type(ctx, field)
+func (ec *executionContext) _IPBlockTypeUpdatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField, obj *IPBlockTypeUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockTypeUpdatePayload_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4916,7 +4917,7 @@ func (ec *executionContext) _IPBlockTypeUpdatePayload_ip_block_type(ctx context.
 	return ec.marshalNIPBlockType2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockTypeUpdatePayload_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockTypeUpdatePayload_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockTypeUpdatePayload",
 		Field:      field,
@@ -4943,8 +4944,8 @@ func (ec *executionContext) fieldContext_IPBlockTypeUpdatePayload_ip_block_type(
 	return fc, nil
 }
 
-func (ec *executionContext) _IPBlockUpdatePayload_ip_block(ctx context.Context, field graphql.CollectedField, obj *IPBlockUpdatePayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_IPBlockUpdatePayload_ip_block(ctx, field)
+func (ec *executionContext) _IPBlockUpdatePayload_ipBlock(ctx context.Context, field graphql.CollectedField, obj *IPBlockUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IPBlockUpdatePayload_ipBlock(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -4974,7 +4975,7 @@ func (ec *executionContext) _IPBlockUpdatePayload_ip_block(ctx context.Context, 
 	return ec.marshalNIPBlock2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlock(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_IPBlockUpdatePayload_ip_block(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_IPBlockUpdatePayload_ipBlock(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "IPBlockUpdatePayload",
 		Field:      field,
@@ -5044,8 +5045,8 @@ func (ec *executionContext) fieldContext_Mutation_createIPAddress(ctx context.Co
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_address":
-				return ec.fieldContext_IPAddressCreatePayload_ip_address(ctx, field)
+			case "ipAddress":
+				return ec.fieldContext_IPAddressCreatePayload_ipAddress(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPAddressCreatePayload", field.Name)
 		},
@@ -5103,8 +5104,8 @@ func (ec *executionContext) fieldContext_Mutation_updateIPAddress(ctx context.Co
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_address":
-				return ec.fieldContext_IPAddressUpdatePayload_ip_address(ctx, field)
+			case "ipAddress":
+				return ec.fieldContext_IPAddressUpdatePayload_ipAddress(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPAddressUpdatePayload", field.Name)
 		},
@@ -5221,8 +5222,8 @@ func (ec *executionContext) fieldContext_Mutation_createIPBlock(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block":
-				return ec.fieldContext_IPBlockCreatePayload_ip_block(ctx, field)
+			case "ipBlock":
+				return ec.fieldContext_IPBlockCreatePayload_ipBlock(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockCreatePayload", field.Name)
 		},
@@ -5280,8 +5281,8 @@ func (ec *executionContext) fieldContext_Mutation_updateIPBlock(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block":
-				return ec.fieldContext_IPBlockUpdatePayload_ip_block(ctx, field)
+			case "ipBlock":
+				return ec.fieldContext_IPBlockUpdatePayload_ipBlock(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockUpdatePayload", field.Name)
 		},
@@ -5398,8 +5399,8 @@ func (ec *executionContext) fieldContext_Mutation_createIPBlockType(ctx context.
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block_type":
-				return ec.fieldContext_IPBlockTypeCreatePayload_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_IPBlockTypeCreatePayload_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockTypeCreatePayload", field.Name)
 		},
@@ -5457,8 +5458,8 @@ func (ec *executionContext) fieldContext_Mutation_updateIPBlockType(ctx context.
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "ip_block_type":
-				return ec.fieldContext_IPBlockTypeUpdatePayload_ip_block_type(ctx, field)
+			case "ipBlockType":
+				return ec.fieldContext_IPBlockTypeUpdatePayload_ipBlockType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type IPBlockTypeUpdatePayload", field.Name)
 		},
@@ -5706,8 +5707,8 @@ func (ec *executionContext) fieldContext_PageInfo_endCursor(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_ip_address(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_ip_address(ctx, field)
+func (ec *executionContext) _Query_ipAddress(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ipAddress(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -5737,7 +5738,7 @@ func (ec *executionContext) _Query_ip_address(ctx context.Context, field graphql
 	return ec.marshalNIPAddress2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPAddress(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_ip_address(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_ipAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5770,15 +5771,15 @@ func (ec *executionContext) fieldContext_Query_ip_address(ctx context.Context, f
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_ip_address_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_ipAddress_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_ip_block(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_ip_block(ctx, field)
+func (ec *executionContext) _Query_ipBlock(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ipBlock(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -5808,7 +5809,7 @@ func (ec *executionContext) _Query_ip_block(ctx context.Context, field graphql.C
 	return ec.marshalNIPBlock2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlock(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_ip_block(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_ipBlock(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5843,15 +5844,15 @@ func (ec *executionContext) fieldContext_Query_ip_block(ctx context.Context, fie
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_ip_block_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_ipBlock_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_ip_block_type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_ip_block_type(ctx, field)
+func (ec *executionContext) _Query_ipBlockType(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -5881,7 +5882,7 @@ func (ec *executionContext) _Query_ip_block_type(ctx context.Context, field grap
 	return ec.marshalNIPBlockType2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockType(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -5912,7 +5913,7 @@ func (ec *executionContext) fieldContext_Query_ip_block_type(ctx context.Context
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_ip_block_type_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_ipBlockType_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -6195,8 +6196,8 @@ func (ec *executionContext) fieldContext_ResourceOwner_id(ctx context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _ResourceOwner_ip_block_type(ctx context.Context, field graphql.CollectedField, obj *ResourceOwner) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ResourceOwner_ip_block_type(ctx, field)
+func (ec *executionContext) _ResourceOwner_ipBlockType(ctx context.Context, field graphql.CollectedField, obj *ResourceOwner) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ResourceOwner_ipBlockType(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -6226,7 +6227,7 @@ func (ec *executionContext) _ResourceOwner_ip_block_type(ctx context.Context, fi
 	return ec.marshalNIPBlockTypeConnection2ᚖgoᚗinfratographerᚗcomᚋipamᚑapiᚋinternalᚋentᚋgeneratedᚐIPBlockTypeConnection(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_ResourceOwner_ip_block_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_ResourceOwner_ipBlockType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ResourceOwner",
 		Field:      field,
@@ -6251,7 +6252,7 @@ func (ec *executionContext) fieldContext_ResourceOwner_ip_block_type(ctx context
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_ResourceOwner_ip_block_type_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_ResourceOwner_ipBlockType_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -10171,8 +10172,8 @@ func (ec *executionContext) _IPAddressCreatePayload(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPAddressCreatePayload")
-		case "ip_address":
-			out.Values[i] = ec._IPAddressCreatePayload_ip_address(ctx, field, obj)
+		case "ipAddress":
+			out.Values[i] = ec._IPAddressCreatePayload_ipAddress(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10290,8 +10291,8 @@ func (ec *executionContext) _IPAddressUpdatePayload(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPAddressUpdatePayload")
-		case "ip_address":
-			out.Values[i] = ec._IPAddressUpdatePayload_ip_address(ctx, field, obj)
+		case "ipAddress":
+			out.Values[i] = ec._IPAddressUpdatePayload_ipAddress(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10586,8 +10587,8 @@ func (ec *executionContext) _IPBlockCreatePayload(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockCreatePayload")
-		case "ip_block":
-			out.Values[i] = ec._IPBlockCreatePayload_ip_block(ctx, field, obj)
+		case "ipBlock":
+			out.Values[i] = ec._IPBlockCreatePayload_ipBlock(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10877,8 +10878,8 @@ func (ec *executionContext) _IPBlockTypeCreatePayload(ctx context.Context, sel a
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockTypeCreatePayload")
-		case "ip_block_type":
-			out.Values[i] = ec._IPBlockTypeCreatePayload_ip_block_type(ctx, field, obj)
+		case "ipBlockType":
+			out.Values[i] = ec._IPBlockTypeCreatePayload_ipBlockType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10996,8 +10997,8 @@ func (ec *executionContext) _IPBlockTypeUpdatePayload(ctx context.Context, sel a
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockTypeUpdatePayload")
-		case "ip_block_type":
-			out.Values[i] = ec._IPBlockTypeUpdatePayload_ip_block_type(ctx, field, obj)
+		case "ipBlockType":
+			out.Values[i] = ec._IPBlockTypeUpdatePayload_ipBlockType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -11035,8 +11036,8 @@ func (ec *executionContext) _IPBlockUpdatePayload(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("IPBlockUpdatePayload")
-		case "ip_block":
-			out.Values[i] = ec._IPBlockUpdatePayload_ip_block(ctx, field, obj)
+		case "ipBlock":
+			out.Values[i] = ec._IPBlockUpdatePayload_ipBlock(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -11235,7 +11236,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Query")
-		case "ip_address":
+		case "ipAddress":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11244,7 +11245,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_ip_address(ctx, field)
+				res = ec._Query_ipAddress(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11257,7 +11258,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "ip_block":
+		case "ipBlock":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11266,7 +11267,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_ip_block(ctx, field)
+				res = ec._Query_ipBlock(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11279,7 +11280,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "ip_block_type":
+		case "ipBlockType":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11288,7 +11289,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_ip_block_type(ctx, field)
+				res = ec._Query_ipBlockType(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11392,7 +11393,7 @@ func (ec *executionContext) _ResourceOwner(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "ip_block_type":
+		case "ipBlockType":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -11401,7 +11402,7 @@ func (ec *executionContext) _ResourceOwner(ctx context.Context, sel ast.Selectio
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._ResourceOwner_ip_block_type(ctx, field, obj)
+				res = ec._ResourceOwner_ipBlockType(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/testclient/gen_client.go
+++ b/internal/testclient/gen_client.go
@@ -37,9 +37,9 @@ func NewClient(cli *http.Client, baseURL string, options ...client.HTTPRequestOp
 }
 
 type Query struct {
-	IPAddress   IPAddress   "json:\"ip_address\" graphql:\"ip_address\""
-	IPBlock     IPBlock     "json:\"ip_block\" graphql:\"ip_block\""
-	IPBlockType IPBlockType "json:\"ip_block_type\" graphql:\"ip_block_type\""
+	IPAddress   IPAddress   "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPBlock     IPBlock     "json:\"ipBlock\" graphql:\"ipBlock\""
+	IPBlockType IPBlockType "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	Entities    []Entity    "json:\"_entities\" graphql:\"_entities\""
 	Service     Service     "json:\"_service\" graphql:\"_service\""
 }
@@ -71,7 +71,7 @@ type CreateIPAddress struct {
 					} "json:\"edges\" graphql:\"edges\""
 				} "json:\"ipAddress\" graphql:\"ipAddress\""
 			} "json:\"ipBlock\" graphql:\"ipBlock\""
-		} "json:\"ip_address\" graphql:\"ip_address\""
+		} "json:\"ipAddress\" graphql:\"ipAddress\""
 	} "json:\"createIPAddress\" graphql:\"createIPAddress\""
 }
 type DeleteIPAddress struct {
@@ -104,7 +104,7 @@ type GetIPBlock struct {
 				} "json:\"node\" graphql:\"node\""
 			} "json:\"edges\" graphql:\"edges\""
 		} "json:\"ipAddress\" graphql:\"ipAddress\""
-	} "json:\"ip_block\" graphql:\"ip_block\""
+	} "json:\"ipBlock\" graphql:\"ipBlock\""
 }
 type GetIPBlockType struct {
 	IPBlockType struct {
@@ -115,7 +115,7 @@ type GetIPBlockType struct {
 		} "json:\"owner\" graphql:\"owner\""
 		CreatedAt time.Time "json:\"createdAt\" graphql:\"createdAt\""
 		UpdatedAt time.Time "json:\"updatedAt\" graphql:\"updatedAt\""
-	} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+	} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 }
 type IPBlockCreate struct {
 	CreateIPBlock struct {
@@ -136,7 +136,7 @@ type IPBlockCreate struct {
 					} "json:\"node\" graphql:\"node\""
 				} "json:\"edges\" graphql:\"edges\""
 			} "json:\"ipAddress\" graphql:\"ipAddress\""
-		} "json:\"ip_block\" graphql:\"ip_block\""
+		} "json:\"ipBlock\" graphql:\"ipBlock\""
 	} "json:\"createIPBlock\" graphql:\"createIPBlock\""
 }
 type IPBlockDelete struct {
@@ -154,7 +154,7 @@ type IPBlockTypeCreate struct {
 			} "json:\"owner\" graphql:\"owner\""
 			CreatedAt time.Time "json:\"createdAt\" graphql:\"createdAt\""
 			UpdatedAt time.Time "json:\"updatedAt\" graphql:\"updatedAt\""
-		} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+		} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	} "json:\"createIPBlockType\" graphql:\"createIPBlockType\""
 }
 type IPBlockTypeDelete struct {
@@ -169,7 +169,7 @@ type IPBlockTypeUpdate struct {
 			Name      string          "json:\"name\" graphql:\"name\""
 			CreatedAt time.Time       "json:\"createdAt\" graphql:\"createdAt\""
 			UpdatedAt time.Time       "json:\"updatedAt\" graphql:\"updatedAt\""
-		} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+		} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	} "json:\"updateIPBlockType\" graphql:\"updateIPBlockType\""
 }
 type IPBlockUpdate struct {
@@ -191,7 +191,7 @@ type IPBlockUpdate struct {
 					} "json:\"node\" graphql:\"node\""
 				} "json:\"edges\" graphql:\"edges\""
 			} "json:\"ipAddress\" graphql:\"ipAddress\""
-		} "json:\"ip_block\" graphql:\"ip_block\""
+		} "json:\"ipBlock\" graphql:\"ipBlock\""
 	} "json:\"updateIPBlock\" graphql:\"updateIPBlock\""
 }
 type ListIPBlockTypes struct {
@@ -203,7 +203,7 @@ type ListIPBlockTypes struct {
 					Name string          "json:\"name\" graphql:\"name\""
 				} "json:\"node\" graphql:\"node\""
 			} "json:\"edges\" graphql:\"edges\""
-		} "json:\"ip_block_type\" graphql:\"ip_block_type\""
+		} "json:\"ipBlockType\" graphql:\"ipBlockType\""
 	} "json:\"_entities\" graphql:\"_entities\""
 }
 type UpdateIPAddress struct {
@@ -223,7 +223,7 @@ type UpdateIPAddress struct {
 					} "json:\"edges\" graphql:\"edges\""
 				} "json:\"ipAddress\" graphql:\"ipAddress\""
 			} "json:\"ipBlock\" graphql:\"ipBlock\""
-		} "json:\"ip_address\" graphql:\"ip_address\""
+		} "json:\"ipAddress\" graphql:\"ipAddress\""
 	} "json:\"updateIPAddress\" graphql:\"updateIPAddress\""
 }
 type GetIPAddress struct {
@@ -237,12 +237,12 @@ type GetIPAddress struct {
 			AllowAutoAllocate bool            "json:\"allowAutoAllocate\" graphql:\"allowAutoAllocate\""
 			AllowAutoSubnet   bool            "json:\"allowAutoSubnet\" graphql:\"allowAutoSubnet\""
 		} "json:\"ipBlock\" graphql:\"ipBlock\""
-	} "json:\"ip_address\" graphql:\"ip_address\""
+	} "json:\"ipAddress\" graphql:\"ipAddress\""
 }
 
 const CreateIPAddressDocument = `mutation CreateIPAddress ($input: CreateIPAddressInput!) {
 	createIPAddress(input: $input) {
-		ip_address {
+		ipAddress {
 			id
 			ip
 			reserved
@@ -320,7 +320,7 @@ func (c *Client) GetIPAddressesByNode(ctx context.Context, id gidx.PrefixedID, h
 }
 
 const GetIPBlockDocument = `query GetIPBlock ($id: ID!) {
-	ip_block(id: $id) {
+	ipBlock(id: $id) {
 		id
 		prefix
 		allowAutoSubnet
@@ -355,7 +355,7 @@ func (c *Client) GetIPBlock(ctx context.Context, id gidx.PrefixedID, httpRequest
 }
 
 const GetIPBlockTypeDocument = `query GetIPBlockType ($id: ID!) {
-	ip_block_type(id: $id) {
+	ipBlockType(id: $id) {
 		id
 		name
 		owner {
@@ -382,7 +382,7 @@ func (c *Client) GetIPBlockType(ctx context.Context, id gidx.PrefixedID, httpReq
 
 const IPBlockCreateDocument = `mutation IPBlockCreate ($input: CreateIPBlockInput!) {
 	createIPBlock(input: $input) {
-		ip_block {
+		ipBlock {
 			id
 			prefix
 			allowAutoSubnet
@@ -439,7 +439,7 @@ func (c *Client) IPBlockDelete(ctx context.Context, id gidx.PrefixedID, httpRequ
 
 const IPBlockTypeCreateDocument = `mutation IPBlockTypeCreate ($input: CreateIPBlockTypeInput!) {
 	createIPBlockType(input: $input) {
-		ip_block_type {
+		ipBlockType {
 			id
 			name
 			owner {
@@ -487,7 +487,7 @@ func (c *Client) IPBlockTypeDelete(ctx context.Context, id gidx.PrefixedID, http
 
 const IPBlockTypeUpdateDocument = `mutation IPBlockTypeUpdate ($id: ID!, $input: UpdateIPBlockTypeInput!) {
 	updateIPBlockType(id: $id, input: $input) {
-		ip_block_type {
+		ipBlockType {
 			id
 			name
 			createdAt
@@ -513,7 +513,7 @@ func (c *Client) IPBlockTypeUpdate(ctx context.Context, id gidx.PrefixedID, inpu
 
 const IPBlockUpdateDocument = `mutation IPBlockUpdate ($id: ID!, $input: UpdateIPBlockInput!) {
 	updateIPBlock(id: $id, input: $input) {
-		ip_block {
+		ipBlock {
 			id
 			prefix
 			allowAutoSubnet
@@ -552,7 +552,7 @@ func (c *Client) IPBlockUpdate(ctx context.Context, id gidx.PrefixedID, input Up
 const ListIPBlockTypesDocument = `query ListIPBlockTypes ($id: ID!, $orderBy: IPBlockTypeOrder) {
 	_entities(representations: [{__typename:"ResourceOwner",id:$id}]) {
 		... on ResourceOwner {
-			ip_block_type(orderBy: $orderBy) {
+			ipBlockType(orderBy: $orderBy) {
 				edges {
 					node {
 						id
@@ -581,7 +581,7 @@ func (c *Client) ListIPBlockTypes(ctx context.Context, id gidx.PrefixedID, order
 
 const UpdateIPAddressDocument = `mutation UpdateIPAddress ($id: ID!, $input: UpdateIPAddressInput!) {
 	updateIPAddress(id: $id, input: $input) {
-		ip_address {
+		ipAddress {
 			id
 			ip
 			reserved
@@ -616,7 +616,7 @@ func (c *Client) UpdateIPAddress(ctx context.Context, id gidx.PrefixedID, input 
 }
 
 const GetIPAddressDocument = `query getIPAddress ($id: ID!) {
-	ip_address(id: $id) {
+	ipAddress(id: $id) {
 		id
 		ip
 		reserved

--- a/internal/testclient/gen_models.go
+++ b/internal/testclient/gen_models.go
@@ -92,13 +92,13 @@ type IPAddressConnection struct {
 
 // Return response for createIPAddress mutation
 type IPAddressCreatePayload struct {
-	// Created ip block type
-	IPAddress IPAddress `json:"ip_address"`
+	// Created ip address
+	IPAddress IPAddress `json:"ipAddress"`
 }
 
 // Return response for deleteIPAddress mutation
 type IPAddressDeletePayload struct {
-	// Deleted ip block type
+	// Deleted ip address ID
 	DeletedID gidx.PrefixedID `json:"deletedID"`
 }
 
@@ -120,8 +120,8 @@ type IPAddressOrder struct {
 
 // Return response for updateIPAddress mutation
 type IPAddressUpdatePayload struct {
-	// Updated ip block type
-	IPAddress IPAddress `json:"ip_address"`
+	// Updated ip address
+	IPAddress IPAddress `json:"ipAddress"`
 }
 
 // IPAddressWhereInput is used for filtering IPAddress objects.
@@ -222,13 +222,13 @@ type IPBlockConnection struct {
 
 // Return response for createIPBlock mutation
 type IPBlockCreatePayload struct {
-	// Created ip block type
-	IPBlock IPBlock `json:"ip_block"`
+	// Created ip block
+	IPBlock IPBlock `json:"ipBlock"`
 }
 
 // Return response for deleteIPBlock mutation
 type IPBlockDeletePayload struct {
-	// Deleted ip block type
+	// Deleted ip block
 	DeletedID gidx.PrefixedID `json:"deletedID"`
 }
 
@@ -280,7 +280,7 @@ type IPBlockTypeConnection struct {
 // Return response for createIPBlockType mutation
 type IPBlockTypeCreatePayload struct {
 	// Created ip block type
-	IPBlockType IPBlockType `json:"ip_block_type"`
+	IPBlockType IPBlockType `json:"ipBlockType"`
 }
 
 // Return response for deleteIPBlockType mutation
@@ -308,7 +308,7 @@ type IPBlockTypeOrder struct {
 // Return response for updateIPBlockType mutation
 type IPBlockTypeUpdatePayload struct {
 	// Updated ip block type
-	IPBlockType IPBlockType `json:"ip_block_type"`
+	IPBlockType IPBlockType `json:"ipBlockType"`
 }
 
 // IPBlockTypeWhereInput is used for filtering IPBlockType objects.
@@ -365,8 +365,8 @@ type IPBlockTypeWhereInput struct {
 
 // Return response for updateIPBlock mutation
 type IPBlockUpdatePayload struct {
-	// Updated ip block type
-	IPBlock IPBlock `json:"ip_block"`
+	// Updated ip block
+	IPBlock IPBlock `json:"ipBlock"`
 }
 
 // IPBlockWhereInput is used for filtering IPBlock objects.
@@ -445,7 +445,7 @@ type PageInfo struct {
 
 type ResourceOwner struct {
 	ID          gidx.PrefixedID       `json:"id"`
-	IPBlockType IPBlockTypeConnection `json:"ip_block_type"`
+	IPBlockType IPBlockTypeConnection `json:"ipBlockType"`
 }
 
 func (ResourceOwner) IsEntity() {}

--- a/internal/testclient/ipaddress.gql
+++ b/internal/testclient/ipaddress.gql
@@ -1,5 +1,5 @@
 query getIPAddress($id: ID!) {
-  ip_address(id: $id) {
+  ipAddress(id: $id) {
     id
     ip
     reserved
@@ -14,7 +14,7 @@ query getIPAddress($id: ID!) {
 
 mutation CreateIPAddress($input: CreateIPAddressInput!) {
   createIPAddress(input: $input) {
-    ip_address {
+    ipAddress {
       id
       ip
       reserved
@@ -35,7 +35,7 @@ mutation CreateIPAddress($input: CreateIPAddressInput!) {
 
 mutation UpdateIPAddress($id: ID!, $input: UpdateIPAddressInput!) {
   updateIPAddress(id: $id, input: $input) {
-    ip_address {
+    ipAddress {
       id
       ip
       reserved

--- a/internal/testclient/ipblock.gql
+++ b/internal/testclient/ipblock.gql
@@ -1,5 +1,5 @@
 query GetIPBlock($id: ID!) {
-  ip_block(id: $id) {
+  ipBlock(id: $id) {
     id
     prefix
     allowAutoSubnet
@@ -21,7 +21,7 @@ query GetIPBlock($id: ID!) {
 
 mutation IPBlockCreate($input: CreateIPBlockInput!) {
     createIPBlock(input: $input) {
-        ip_block {
+        ipBlock {
             id
             prefix
             allowAutoSubnet
@@ -45,7 +45,7 @@ mutation IPBlockCreate($input: CreateIPBlockInput!) {
 
 mutation IPBlockUpdate($id: ID!, $input: UpdateIPBlockInput!) {
     updateIPBlock(id: $id, input: $input) {
-        ip_block {
+        ipBlock {
             id
             prefix
             allowAutoSubnet

--- a/internal/testclient/ipblocktype.gql
+++ b/internal/testclient/ipblocktype.gql
@@ -1,5 +1,5 @@
 query GetIPBlockType($id: ID!) {
-    ip_block_type(id: $id) {
+    ipBlockType(id: $id) {
         id
         name
         owner{
@@ -13,7 +13,7 @@ query GetIPBlockType($id: ID!) {
 query ListIPBlockTypes($id:ID!, $orderBy: IPBlockTypeOrder){
     _entities(representations: [{__typename: "ResourceOwner", id: $id}]) {
         ... on ResourceOwner {
-            ip_block_type(orderBy: $orderBy) {
+            ipBlockType(orderBy: $orderBy) {
                 edges {
                     node {
                         id
@@ -27,7 +27,7 @@ query ListIPBlockTypes($id:ID!, $orderBy: IPBlockTypeOrder){
 
 mutation IPBlockTypeCreate($input: CreateIPBlockTypeInput!) {
     createIPBlockType(input: $input) {
-        ip_block_type {
+        ipBlockType {
             id
             name
             owner{
@@ -41,7 +41,7 @@ mutation IPBlockTypeCreate($input: CreateIPBlockTypeInput!) {
 
 mutation IPBlockTypeUpdate($id: ID!,$input: UpdateIPBlockTypeInput!) {
     updateIPBlockType(id: $id input: $input) {
-        ip_block_type {
+        ipBlockType {
             id
             name
             createdAt

--- a/internal/testclient/schema/schema.graphql
+++ b/internal/testclient/schema/schema.graphql
@@ -74,12 +74,12 @@ type IPAddressConnection {
 }
 """Return response for createIPAddress mutation"""
 type IPAddressCreatePayload {
-	"""Created ip block type"""
-	ip_address: IPAddress!
+	"""Created ip address"""
+	ipAddress: IPAddress!
 }
 """Return response for deleteIPAddress mutation"""
 type IPAddressDeletePayload {
-	"""Deleted ip block type"""
+	"""Deleted ip address ID"""
 	deletedID: ID!
 }
 """An edge in a connection."""
@@ -109,8 +109,8 @@ enum IPAddressOrderField {
 }
 """Return response for updateIPAddress mutation"""
 type IPAddressUpdatePayload {
-	"""Updated ip block type"""
-	ip_address: IPAddress!
+	"""Updated ip address"""
+	ipAddress: IPAddress!
 }
 """
 IPAddressWhereInput is used for filtering IPAddress objects.
@@ -217,12 +217,12 @@ type IPBlockConnection {
 }
 """Return response for createIPBlock mutation"""
 type IPBlockCreatePayload {
-	"""Created ip block type"""
-	ip_block: IPBlock!
+	"""Created ip block"""
+	ipBlock: IPBlock!
 }
 """Return response for deleteIPBlock mutation"""
 type IPBlockDeletePayload {
-	"""Deleted ip block type"""
+	"""Deleted ip block"""
 	deletedID: ID!
 }
 """An edge in a connection."""
@@ -292,7 +292,7 @@ type IPBlockTypeConnection {
 """Return response for createIPBlockType mutation"""
 type IPBlockTypeCreatePayload {
 	"""Created ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """Return response for deleteIPBlockType mutation"""
 type IPBlockTypeDeletePayload {
@@ -324,7 +324,7 @@ enum IPBlockTypeOrderField {
 """Return response for updateIPBlockType mutation"""
 type IPBlockTypeUpdatePayload {
 	"""Updated ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """
 IPBlockTypeWhereInput is used for filtering IPBlockType objects.
@@ -381,8 +381,8 @@ input IPBlockTypeWhereInput {
 }
 """Return response for updateIPBlock mutation"""
 type IPBlockUpdatePayload {
-	"""Updated ip block type"""
-	ip_block: IPBlock!
+	"""Updated ip block"""
+	ipBlock: IPBlock!
 }
 """
 IPBlockWhereInput is used for filtering IPBlock objects.
@@ -449,40 +449,40 @@ input IPBlockWhereInput {
 """A valid JSON string."""
 scalar JSON
 type Mutation {
-	"""Create a new ip block type"""
+	"""Create a new ip address"""
 	createIPAddress(
-		"""Name of the ip block type"""
+		"""values of the ip address"""
 		input: CreateIPAddressInput!
 	): IPAddressCreatePayload!
-	"""Update an existing ip block type"""
+	"""Update an existing ip address"""
 	updateIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address"""
 		id: ID!
 
-		"""Name of the ip block type"""
+		"""New values for the ip address"""
 		input: UpdateIPAddressInput!
 	): IPAddressUpdatePayload!
-	"""Delete an existing ip block type"""
+	"""Delete an existing ip address"""
 	deleteIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address"""
 		id: ID!
 	): IPAddressDeletePayload!
-	"""Create a new ip block type"""
+	"""Create a new ip block"""
 	createIPBlock(
-		"""Name of the ip block type"""
+		"""Name of the ip block"""
 		input: CreateIPBlockInput!
 	): IPBlockCreatePayload!
-	"""Update an existing ip block type"""
+	"""Update an existing ip block"""
 	updateIPBlock(
-		"""ID of the ip block type"""
+		"""ID of the ip block"""
 		id: ID!
 
-		"""Name of the ip block type"""
+		"""Name of the ip block"""
 		input: UpdateIPBlockInput!
 	): IPBlockUpdatePayload!
-	"""Delete an existing ip block type"""
+	"""Delete an existing ip block"""
 	deleteIPBlock(
-		"""ID of the ip block type"""
+		"""ID of the ip block"""
 		id: ID!
 	): IPBlockDeletePayload!
 	"""Create a new ip block type"""
@@ -534,18 +534,18 @@ type PageInfo @shareable {
 	endCursor: Cursor
 }
 type Query {
-	"""Look up ip block type by ID"""
-	ip_address(
-		"""ID of the ip block type"""
+	"""Look up ip address by ID"""
+	ipAddress(
+		"""ID of the ip address"""
 		id: ID!
 	): IPAddress!
-	"""Look up ip block type by ID"""
-	ip_block(
-		"""ID of the ip block type"""
+	"""Look up ip block by ID"""
+	ipBlock(
+		"""ID of the ip block"""
 		id: ID!
 	): IPBlock!
 	"""Look up ip block type by ID"""
-	ip_block_type(
+	ipBlockType(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPBlockType!
@@ -554,7 +554,7 @@ type Query {
 }
 type ResourceOwner @key(fields: "id") @interfaceObject {
 	id: ID!
-	ip_block_type(
+	ipBlockType(
 		"""Returns the elements in the list that come after the specified cursor."""
 		after: Cursor
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -61,12 +61,12 @@ type IPAddressConnection {
 }
 """Return response for createIPAddress mutation"""
 type IPAddressCreatePayload {
-	"""Created ip block type"""
-	ip_address: IPAddress!
+	"""Created ip address"""
+	ipAddress: IPAddress!
 }
 """Return response for deleteIPAddress mutation"""
 type IPAddressDeletePayload {
-	"""Deleted ip block type"""
+	"""Deleted ip address ID"""
 	deletedID: ID!
 }
 """An edge in a connection."""
@@ -96,8 +96,8 @@ enum IPAddressOrderField {
 }
 """Return response for updateIPAddress mutation"""
 type IPAddressUpdatePayload {
-	"""Updated ip block type"""
-	ip_address: IPAddress!
+	"""Updated ip address"""
+	ipAddress: IPAddress!
 }
 """
 IPAddressWhereInput is used for filtering IPAddress objects.
@@ -204,12 +204,12 @@ type IPBlockConnection {
 }
 """Return response for createIPBlock mutation"""
 type IPBlockCreatePayload {
-	"""Created ip block type"""
-	ip_block: IPBlock!
+	"""Created ip block"""
+	ipBlock: IPBlock!
 }
 """Return response for deleteIPBlock mutation"""
 type IPBlockDeletePayload {
-	"""Deleted ip block type"""
+	"""Deleted ip block"""
 	deletedID: ID!
 }
 """An edge in a connection."""
@@ -279,7 +279,7 @@ type IPBlockTypeConnection {
 """Return response for createIPBlockType mutation"""
 type IPBlockTypeCreatePayload {
 	"""Created ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """Return response for deleteIPBlockType mutation"""
 type IPBlockTypeDeletePayload {
@@ -311,7 +311,7 @@ enum IPBlockTypeOrderField {
 """Return response for updateIPBlockType mutation"""
 type IPBlockTypeUpdatePayload {
 	"""Updated ip block type"""
-	ip_block_type: IPBlockType!
+	ipBlockType: IPBlockType!
 }
 """
 IPBlockTypeWhereInput is used for filtering IPBlockType objects.
@@ -368,8 +368,8 @@ input IPBlockTypeWhereInput {
 }
 """Return response for updateIPBlock mutation"""
 type IPBlockUpdatePayload {
-	"""Updated ip block type"""
-	ip_block: IPBlock!
+	"""Updated ip block"""
+	ipBlock: IPBlock!
 }
 """
 IPBlockWhereInput is used for filtering IPBlock objects.
@@ -436,40 +436,40 @@ input IPBlockWhereInput {
 """A valid JSON string."""
 scalar JSON
 type Mutation {
-	"""Create a new ip block type"""
+	"""Create a new ip address"""
 	createIPAddress(
-		"""Name of the ip block type"""
+		"""values of the ip address"""
 		input: CreateIPAddressInput!
 	): IPAddressCreatePayload!
-	"""Update an existing ip block type"""
+	"""Update an existing ip address"""
 	updateIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address"""
 		id: ID!
 
-		"""Name of the ip block type"""
+		"""New values for the ip address"""
 		input: UpdateIPAddressInput!
 	): IPAddressUpdatePayload!
-	"""Delete an existing ip block type"""
+	"""Delete an existing ip address"""
 	deleteIPAddress(
-		"""ID of the ip block type"""
+		"""ID of the ip address"""
 		id: ID!
 	): IPAddressDeletePayload!
-	"""Create a new ip block type"""
+	"""Create a new ip block"""
 	createIPBlock(
-		"""Name of the ip block type"""
+		"""Name of the ip block"""
 		input: CreateIPBlockInput!
 	): IPBlockCreatePayload!
-	"""Update an existing ip block type"""
+	"""Update an existing ip block"""
 	updateIPBlock(
-		"""ID of the ip block type"""
+		"""ID of the ip block"""
 		id: ID!
 
-		"""Name of the ip block type"""
+		"""Name of the ip block"""
 		input: UpdateIPBlockInput!
 	): IPBlockUpdatePayload!
-	"""Delete an existing ip block type"""
+	"""Delete an existing ip block"""
 	deleteIPBlock(
-		"""ID of the ip block type"""
+		"""ID of the ip block"""
 		id: ID!
 	): IPBlockDeletePayload!
 	"""Create a new ip block type"""
@@ -521,18 +521,18 @@ type PageInfo @shareable {
 	endCursor: Cursor
 }
 type Query {
-	"""Look up ip block type by ID"""
-	ip_address(
-		"""ID of the ip block type"""
+	"""Look up ip address by ID"""
+	ipAddress(
+		"""ID of the ip address"""
 		id: ID!
 	): IPAddress!
-	"""Look up ip block type by ID"""
-	ip_block(
-		"""ID of the ip block type"""
+	"""Look up ip block by ID"""
+	ipBlock(
+		"""ID of the ip block"""
 		id: ID!
 	): IPBlock!
 	"""Look up ip block type by ID"""
-	ip_block_type(
+	ipBlockType(
 		"""ID of the ip block type"""
 		id: ID!
 	): IPBlockType!
@@ -541,7 +541,7 @@ type Query {
 }
 type ResourceOwner @key(fields: "id") @interfaceObject {
 	id: ID!
-	ip_block_type(
+	ipBlockType(
 		"""Returns the elements in the list that come after the specified cursor."""
 		after: Cursor
 

--- a/schema/ipaddress.graphql
+++ b/schema/ipaddress.graphql
@@ -1,10 +1,10 @@
 extend type Query {
     """
-    Look up ip block type by ID
+    Look up ip address by ID
     """
-    ip_address(
+    ipAddress(
         """
-        ID of the ip block type
+        ID of the ip address
         """
         id: ID!
     ): IPAddress!
@@ -12,33 +12,33 @@ extend type Query {
 
 extend type Mutation{
     """
-    Create a new ip block type
+    Create a new ip address
     """
     createIPAddress(
         """
-        Name of the ip block type
+        values of the ip address
         """
         input: CreateIPAddressInput!
     ): IPAddressCreatePayload!
     """
-    Update an existing ip block type
+    Update an existing ip address
     """
     updateIPAddress(
         """
-        ID of the ip block type
+        ID of the ip address
         """
         id: ID!
         """
-        Name of the ip block type
+        New values for the ip address
         """
         input: UpdateIPAddressInput!
     ): IPAddressUpdatePayload!
     """
-    Delete an existing ip block type
+    Delete an existing ip address
     """
     deleteIPAddress(
         """
-        ID of the ip block type
+        ID of the ip address
         """
         id: ID!
     ): IPAddressDeletePayload!
@@ -49,9 +49,9 @@ Return response for createIPAddress mutation
 """
 type IPAddressCreatePayload {
     """
-    Created ip block type
+    Created ip address
     """
-    ip_address: IPAddress!
+    ipAddress: IPAddress!
 }
 
 """
@@ -59,9 +59,9 @@ Return response for updateIPAddress mutation
 """
 type IPAddressUpdatePayload {
     """
-    Updated ip block type
+    Updated ip address
     """
-    ip_address: IPAddress!
+    ipAddress: IPAddress!
 }
 
 """
@@ -69,7 +69,7 @@ Return response for deleteIPAddress mutation
 """
 type IPAddressDeletePayload {
     """
-    Deleted ip block type
+    Deleted ip address ID
     """
     deletedID: ID!
 }

--- a/schema/ipblock.graphql
+++ b/schema/ipblock.graphql
@@ -1,10 +1,10 @@
 extend type Query {
     """
-    Look up ip block type by ID
+    Look up ip block by ID
     """
-    ip_block(
+    ipBlock(
         """
-        ID of the ip block type
+        ID of the ip block
         """
         id: ID!
     ): IPBlock!
@@ -12,33 +12,33 @@ extend type Query {
 
 extend type Mutation{
     """
-    Create a new ip block type
+    Create a new ip block
     """
     createIPBlock(
         """
-        Name of the ip block type
+        Name of the ip block
         """
         input: CreateIPBlockInput!
     ): IPBlockCreatePayload!
     """
-    Update an existing ip block type
+    Update an existing ip block
     """
     updateIPBlock(
         """
-        ID of the ip block type
+        ID of the ip block
         """
         id: ID!
         """
-        Name of the ip block type
+        Name of the ip block
         """
         input: UpdateIPBlockInput!
     ): IPBlockUpdatePayload!
     """
-    Delete an existing ip block type
+    Delete an existing ip block
     """
     deleteIPBlock(
         """
-        ID of the ip block type
+        ID of the ip block
         """
         id: ID!
     ): IPBlockDeletePayload!
@@ -49,9 +49,9 @@ Return response for createIPBlock mutation
 """
 type IPBlockCreatePayload {
     """
-    Created ip block type
+    Created ip block
     """
-    ip_block: IPBlock!
+    ipBlock: IPBlock!
 }
 
 """
@@ -59,9 +59,9 @@ Return response for updateIPBlock mutation
 """
 type IPBlockUpdatePayload {
     """
-    Updated ip block type
+    Updated ip block
     """
-    ip_block: IPBlock!
+    ipBlock: IPBlock!
 }
 
 """
@@ -69,7 +69,7 @@ Return response for deleteIPBlock mutation
 """
 type IPBlockDeletePayload {
     """
-    Deleted ip block type
+    Deleted ip block
     """
     deletedID: ID!
 }

--- a/schema/ipblocktype.graphql
+++ b/schema/ipblocktype.graphql
@@ -2,7 +2,7 @@ extend type Query {
     """
     Look up ip block type by ID
     """
-    ip_block_type(
+    ipBlockType(
         """
         ID of the ip block type
         """
@@ -51,7 +51,7 @@ type IPBlockTypeCreatePayload {
     """
     Created ip block type
     """
-    ip_block_type: IPBlockType!
+    ipBlockType: IPBlockType!
 }
 
 """
@@ -61,7 +61,7 @@ type IPBlockTypeUpdatePayload {
     """
     Updated ip block type
     """
-    ip_block_type: IPBlockType!
+    ipBlockType: IPBlockType!
 }
 
 """

--- a/schema/owner.graphql
+++ b/schema/owner.graphql
@@ -2,7 +2,7 @@ directive @prefixedID(prefix: String!) on OBJECT
 
 type ResourceOwner @key(fields: "id") @interfaceObject {
   id: ID!
-  ip_block_type(
+  ipBlockType(
     """
     Returns the elements in the list that come after the specified cursor.
     """


### PR DESCRIPTION
This finishes renaming all the fields in graphql from things like `ip_address` to `ipAddress`. 

This will be a breaking change for the API.