### PR TITLE
Add method to validate IP Block Prefix

### DIFF
--- a/internal/ent/schema/ip_block.go
+++ b/internal/ent/schema/ip_block.go
@@ -8,6 +8,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 
+	"go.infratographer.com/ipam-api/internal/ent/schema/validator"
 	"go.infratographer.com/ipam-api/x/pubsubinfo"
 
 	"go.infratographer.com/x/entx"
@@ -43,7 +44,8 @@ func (IPBlock) Fields() []ent.Field {
 			Comment("The prefix of the ip block.").
 			Annotations(
 				entgql.OrderField("PREFIX"),
-			),
+			).
+			Validate(validator.IPBlockPref),
 		field.String("block_type_id").
 			GoType(gidx.PrefixedID("")).
 			Immutable().

--- a/internal/ent/schema/validator/validate.go
+++ b/internal/ent/schema/validator/validate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 )
 
 // IPAddr returns error if IP address is NOT valid
@@ -21,4 +22,22 @@ var ErrInvalidIPAddr = errors.New("provided IP Address is invalid")
 // InvalidIPAddrError returns Error Invalid IP Address
 func InvalidIPAddrError(ip string) error {
 	return fmt.Errorf("error %w: %s", ErrInvalidIPAddr, ip)
+}
+
+// IPBlockPref returns error if IP Block Prefix is NOT valid
+func IPBlockPref(prefix string) error {
+	_, err := netip.ParsePrefix(prefix)
+	if err != nil {
+		return InvalidIPPrefError(prefix)
+	}
+
+	return nil
+}
+
+// ErrInvalidIPPref is an error raised when provided IP Block Prefix is invalid
+var ErrInvalidIPPref = errors.New("provided IP Block Prefix is invalid")
+
+// InvalidIPPrefError returns Error Invalid IP Block Prefix
+func InvalidIPPrefError(prefix string) error {
+	return fmt.Errorf("error %w: %s", ErrInvalidIPPref, prefix)
 }


### PR DESCRIPTION
Validate that a prefix is a valid IP prefix for IPBlocks.

https://pkg.go.dev/net/netip#ParsePrefix
